### PR TITLE
Trellis CLI Dynamic Publisher

### DIFF
--- a/trellis/core/publisher.hpp
+++ b/trellis/core/publisher.hpp
@@ -35,6 +35,10 @@ using Publisher = std::shared_ptr<PublisherClass<T>>;
  * types determined at runtime
  *
  * This was adapted from eCAL's CPublisher<T>
+ *
+ * TODO(bsirang): this functionality was integrated upstream...
+ * wipe this version and use the upstream implementation after the next
+ * version of eCAL is released.
  */
 class DynamicPublisherImpl : public eCAL::CMsgPublisher<google::protobuf::Message> {
  public:

--- a/trellis/tools/trellis-cli/topic_main.cpp
+++ b/trellis/tools/trellis-cli/topic_main.cpp
@@ -30,27 +30,59 @@ using namespace trellis::core;
 
 int topic_publish_main(int argc, char* argv[]) {
   cxxopts::Options options("trellis-cli topic publish", "publish messages to a given topic");
-  options.add_options()("t,topic", "topic name", cxxopts::value<std::string>())("m,message", "message type",
-                                                                                cxxopts::value<std::string>())(
+  options.add_options()("t,topic", "topic name", cxxopts::value<std::string>())(
       "b,body", "message body in JSON", cxxopts::value<std::string>())("c,count", "message count",
                                                                        cxxopts::value<int>()->default_value("1"))(
+      "d,delay", "discovery delay milliseconds", cxxopts::value<int>()->default_value("1000"))(
       "r,rate", "publish rate hz", cxxopts::value<int>()->default_value("1"))("h,help", "print usage");
   auto result = options.parse(argc, argv);
-  if (result.count("help") || !result.count("topic") || !result.count("message") || !result.count("body")) {
+  if (result.count("help") || !result.count("topic") || !result.count("body")) {
     std::cout << options.help() << std::endl;
     return 1;
   }
 
   const std::string topic = result["topic"].as<std::string>();
-  const std::string type_name = result["message"].as<std::string>();
   const std::string body = result["body"].as<std::string>();
   const int count = result["count"].as<int>();
   const int rate = result["rate"].as<int>();
+  const int delay_ms = result["delay"].as<int>();
   const int interval_ms = 1000 / rate;
 
   Node node("trellis-cli");
-  auto pub = node.CreateDynamicPublisher(topic, type_name);
-  auto message = DynamicPublisherImpl::CreateMessageByName(type_name);
+
+  // Delay to give time for discovery
+  std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+
+  std::string topic_type = eCAL::Util::GetTypeName(topic);
+  topic_type = topic_type.substr(topic_type.find_first_of(':') + 1, topic_type.size());
+  topic_type = topic_type.substr(topic_type.find_last_of('.') + 1, topic_type.size());
+
+  if (topic_type.size() == 0) {
+    std::cerr << "Could not retrieve topic type for " << topic << ". Are there any subscribers online?" << std::endl;
+    return 1;
+  }
+
+  std::string topic_description = eCAL::Util::GetDescription(topic);
+  if (topic_description.size() == 0) {
+    std::cerr << "Could not retrieve topic description for " << topic << "." << std::endl;
+    return 1;
+  }
+  google::protobuf::FileDescriptorSet proto_desc;
+  proto_desc.ParseFromString(topic_description);
+  eCAL::protobuf::CProtoDynDecoder decoder;
+  std::string error_s;
+
+  // XXX(bsirang) we don't own the memory to the message returned by GetProtoMessageFromDescriptorSet
+  // however we need a shared pointer to comply with the dynamic publisher API, so we create a
+  // wrapper here with a dummy deleter function. This is a slight abuse.
+  std::shared_ptr<google::protobuf::Message> message{
+      decoder.GetProtoMessageFromDescriptorSet(proto_desc, topic_type, error_s), [](google::protobuf::Message*) {}};
+
+  if (error_s.size() > 0 || message == nullptr) {
+    std::cerr << "Could not get proto message from descriptor set. " << error_s << std::endl;
+    return 1;
+  }
+  auto pub = node.CreateDynamicPublisher(topic, message);
 
   google::protobuf::util::JsonParseOptions json_options;
   json_options.ignore_unknown_fields = false;
@@ -59,6 +91,10 @@ int topic_publish_main(int argc, char* argv[]) {
   auto r = google::protobuf::util::JsonStringToMessage(body, message.get(), json_options);
 
   std::cout << "Echoing " << count << " messages at " << rate << " hz to topic " << topic << std::endl;
+
+  // Delay to give time for connection(s) to establish
+  std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+
   for (int i = 0; i < count && node.RunOnce(); ++i) {
     pub->Send(*message);
     if (i < count - 1) {

--- a/trellis/tools/trellis-cli/topic_main.cpp
+++ b/trellis/tools/trellis-cli/topic_main.cpp
@@ -72,11 +72,8 @@ int topic_publish_main(int argc, char* argv[]) {
   eCAL::protobuf::CProtoDynDecoder decoder;
   std::string error_s;
 
-  // XXX(bsirang) we don't own the memory to the message returned by GetProtoMessageFromDescriptorSet
-  // however we need a shared pointer to comply with the dynamic publisher API, so we create a
-  // wrapper here with a dummy deleter function. This is a slight abuse.
   std::shared_ptr<google::protobuf::Message> message{
-      decoder.GetProtoMessageFromDescriptorSet(proto_desc, topic_type, error_s), [](google::protobuf::Message*) {}};
+      decoder.GetProtoMessageFromDescriptorSet(proto_desc, topic_type, error_s)};
 
   if (error_s.size() > 0 || message == nullptr) {
     std::cerr << "Could not get proto message from descriptor set. " << error_s << std::endl;

--- a/trellis/tools/trellis-cli/topic_main.cpp
+++ b/trellis/tools/trellis-cli/topic_main.cpp
@@ -33,7 +33,7 @@ int topic_publish_main(int argc, char* argv[]) {
   options.add_options()("t,topic", "topic name", cxxopts::value<std::string>())(
       "b,body", "message body in JSON", cxxopts::value<std::string>())("c,count", "message count",
                                                                        cxxopts::value<int>()->default_value("1"))(
-      "d,delay", "discovery delay milliseconds", cxxopts::value<int>()->default_value("1000"))(
+      "d,delay", "discovery delay milliseconds", cxxopts::value<int>()->default_value("1500"))(
       "r,rate", "publish rate hz", cxxopts::value<int>()->default_value("1"))("h,help", "print usage");
   auto result = options.parse(argc, argv);
   if (result.count("help") || !result.count("topic") || !result.count("body")) {


### PR DESCRIPTION
Now when using `trellis-cli topic publish` the tool will retrieve the metadata for the topic from any subscribers whom are online. This allows the tool to dynamically construct proto messages with the appropriate schema dynamically.