### PR TITLE
Subscriber Wrapper

### DIFF
--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -63,12 +63,7 @@ class Node {
 
   template <typename T>
   Subscriber<T> CreateSubscriber(std::string topic, std::function<void(const T&)> callback) const {
-    Subscriber<T> subscriber = std::make_shared<SubscriberClass<T>>(topic.c_str());
-    // TODO(bsirang) consider passing time_ and clock_ to user
-    auto callback_wrapper = [callback](const char* topic_name_, const T& msg_, long long time_, long long clock_,
-                                       long long id_) { callback(msg_); };
-    subscriber->AddReceiveCallback(callback_wrapper);
-    return subscriber;
+    return std::make_shared<SubscriberImpl<T>>(topic.c_str(), callback);
   }
 
   DynamicSubscriber CreateDynamicSubscriber(std::string topic,

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -24,14 +24,26 @@
 namespace trellis {
 namespace core {
 
-template <typename T>
-using SubscriberClass = eCAL::protobuf::CSubscriber<T>;
-
-template <typename T>
-using Subscriber = std::shared_ptr<SubscriberClass<T>>;
-
 using DynamicSubscriberClass = eCAL::protobuf::CDynamicSubscriber;
 using DynamicSubscriber = std::shared_ptr<DynamicSubscriberClass>;
+
+template <typename T>
+class SubscriberImpl {
+ public:
+  using Callback = std::function<void(const T&)>;
+  SubscriberImpl(const std::string& topic, Callback callback) : ecal_sub_{topic} {
+    // XXX(bsirang) consider passing time_ and clock_ to user
+    auto callback_wrapper = [callback](const char* topic_name_, const T& msg_, long long time_, long long clock_,
+                                       long long id_) { callback(msg_); };
+    ecal_sub_.AddReceiveCallback(callback_wrapper);
+  }
+
+ private:
+  eCAL::protobuf::CSubscriber<T> ecal_sub_;
+};
+
+template <typename T>
+using Subscriber = std::shared_ptr<SubscriberImpl<T>>;
 
 }  // namespace core
 }  // namespace trellis


### PR DESCRIPTION
Wrapper to class to encapsulate the eCAL subscriber. This is a precursor to adding functionality such as a watchdog timeout.