### PR TITLE
Standalone Logging APIs

### DIFF
--- a/trellis/core/logging.hpp
+++ b/trellis/core/logging.hpp
@@ -28,11 +28,11 @@ namespace Log {
 namespace {
 
 void DoLog(const std::string& msg, const std::string& prefix, eCAL_Logging_eLogLevel level) {
-  if (eCAL::IsInitialized(eCAL::Init::Logging)) {
-    eCAL::Logging::Log(level, prefix + msg);
-  } else {
-    // use fallback logging
+  if (!eCAL::IsInitialized(eCAL::Init::Logging)) {
+    eCAL::Initialize(0, nullptr, nullptr, eCAL::Init::Logging);
   }
+  const std::string full_msg = prefix + msg;
+  eCAL::Logging::Log(level, full_msg);
 }
 
 }  // namespace

--- a/trellis/core/logging.hpp
+++ b/trellis/core/logging.hpp
@@ -25,34 +25,46 @@ namespace trellis {
 namespace core {
 namespace Log {
 
+namespace {
+
+void DoLog(const std::string& msg, const std::string& prefix, eCAL_Logging_eLogLevel level) {
+  if (eCAL::IsInitialized(eCAL::Init::Logging)) {
+    eCAL::Logging::Log(level, prefix + msg);
+  } else {
+    // use fallback logging
+  }
+}
+
+}  // namespace
+
 template <typename... Args>
 inline void Info(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  eCAL::Logging::Log(log_level_info, "[INFO] " + msg);
+  DoLog(msg, "[INFO] ", log_level_info);
 }
 
 template <typename... Args>
 inline void Warn(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  eCAL::Logging::Log(log_level_warning, "[WARN] " + msg);
+  DoLog(msg, "[WARN] ", log_level_warning);
 }
 
 template <typename... Args>
 inline void Error(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  eCAL::Logging::Log(log_level_error, "[ERROR] " + msg);
+  DoLog(msg, "[ERROR] ", log_level_error);
 }
 
 template <typename... Args>
 inline void Fatal(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  eCAL::Logging::Log(log_level_fatal, "[FATAL] " + msg);
+  DoLog(msg, "[FATAL] ", log_level_fatal);
 }
 
 template <typename... Args>
 inline void Debug(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  eCAL::Logging::Log(log_level_debug1, "[DEBUG] " + msg);
+  DoLog(msg, "[DEBUG] ", log_level_debug1);
 }
 
 }  // namespace Log

--- a/trellis/core/logging.hpp
+++ b/trellis/core/logging.hpp
@@ -18,6 +18,7 @@
 #ifndef TRELLIS_CORE_LOGGING_HPP
 #define TRELLIS_CORE_LOGGING_HPP
 
+#include <ecal/ecal.h>
 #include <ecal/ecal_log.h>
 #include <fmt/core.h>
 

--- a/trellis/core/logging.hpp
+++ b/trellis/core/logging.hpp
@@ -40,13 +40,13 @@ void DoLog(const std::string& msg, const std::string& prefix, eCAL_Logging_eLogL
 template <typename... Args>
 inline void Info(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  DoLog(msg, "[INFO] ", log_level_info);
+  DoLog(msg, "[INFO]  ", log_level_info);
 }
 
 template <typename... Args>
 inline void Warn(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  DoLog(msg, "[WARN] ", log_level_warning);
+  DoLog(msg, "[WARN]  ", log_level_warning);
 }
 
 template <typename... Args>

--- a/trellis/core/logging.hpp
+++ b/trellis/core/logging.hpp
@@ -19,7 +19,6 @@
 #define TRELLIS_CORE_LOGGING_HPP
 
 #include <ecal/ecal.h>
-#include <ecal/ecal_log.h>
 #include <fmt/core.h>
 
 namespace trellis {

--- a/trellis/core/node.cpp
+++ b/trellis/core/node.cpp
@@ -22,8 +22,13 @@
 using namespace trellis::core;
 
 Node::Node(std::string name) : name_{name}, ev_loop_{CreateEventLoop()} {
-  // TODO (bsirang): do we ever want to pass argc/argv to eCAL?
-  eCAL::Initialize(0, nullptr, name_.c_str());
+  // XXX(bsirang) eCAL can take argv/argc to parse options for overriding the config filepath and/or specific config
+  // options. We won't make use of that for now. We'll just call Initialize with default arguments.
+  eCAL::Initialize();
+
+  // Instead of passing the unit name as part of Initialize above, we'll set it here explicitly. This ensures the unit
+  // name gets set in cases where we may have called Initialize already, such as from logging APIs.
+  eCAL::SetUnitName(name_.c_str());
 }
 
 Node::~Node() { Stop(); }

--- a/trellis/examples/logger/BUILD
+++ b/trellis/examples/logger/BUILD
@@ -1,0 +1,9 @@
+cc_binary(
+    name = "logger",
+    srcs = [
+        "main.cpp",
+    ],
+    deps = [
+        "//trellis",
+    ],
+)

--- a/trellis/examples/logger/main.cpp
+++ b/trellis/examples/logger/main.cpp
@@ -1,0 +1,28 @@
+#include <sstream>
+#include <thread>
+
+#include "trellis/core/logging.hpp"
+
+int main(int argc, char* argv[]) {
+  unsigned count{0};
+  while (true) {
+    std::stringstream msg;
+    msg << "Logging message " << count;
+
+    // You can use the logging APIs directly without any other explicit trellis initialization. Depending on the
+    // underlying eCAL settings, the log messages will go to various backends, including multicast UDP.
+
+    // Pick and choose different log levels at different iteration counts for demonstration
+    if (count % 10 == 0) {
+      trellis::core::Log::Error(msg.str());
+    } else if (count % 3 == 0) {
+      trellis::core::Log::Warn(msg.str());
+    } else {
+      trellis::core::Log::Info(msg.str());
+    }
+
+    ++count;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  }
+  return 0;
+}


### PR DESCRIPTION
Allow `trellis::core::Log` to be used standalone