### PR TITLE
Message Consumer - Pass Topic in Callbacks

### DIFF
--- a/trellis/core/test/test_message_consumer.cpp
+++ b/trellis/core/test/test_message_consumer.cpp
@@ -37,10 +37,12 @@ TEST_F(TrellisFixture, MultipleMessageTypesWithIndividualCallbacks) {
       node_,
       {{"consumer_topic_1", "consumer_topic_2"}},
       {[this](const std::string& topic, const test::Test& msg, const time::TimePoint&) {
+         ASSERT_EQ(topic, "consumer_topic_1");
          ASSERT_EQ(receive_count_1, msg.id());
          ++receive_count_1;
        },
        [this](const std::string& topic, const test::TestTwo& msg, const time::TimePoint&) {
+         ASSERT_EQ(topic, "consumer_topic_2");
          ASSERT_FLOAT_EQ(receive_count_2, msg.foo() / 2.0);
          ++receive_count_2;
        }}};
@@ -78,10 +80,12 @@ TEST_F(TrellisFixture, MultipleMessageTypesWithIndividualCallbacksAndWatchdogs) 
       node_,
       {{"consumer_topic_1", "consumer_topic_2"}},
       {[this](const std::string& topic, const test::Test& msg, const time::TimePoint&) {
+         ASSERT_EQ(topic, "consumer_topic_1");
          ASSERT_EQ(receive_count_1, msg.id());
          ++receive_count_1;
        },
        [this](const std::string& topic, const test::TestTwo& msg, const time::TimePoint&) {
+         ASSERT_EQ(topic, "consumer_topic_2");
          ASSERT_FLOAT_EQ(receive_count_2, msg.foo() / 2.0);
          ++receive_count_2;
        }},

--- a/trellis/core/test/test_message_consumer.cpp
+++ b/trellis/core/test/test_message_consumer.cpp
@@ -36,11 +36,11 @@ TEST_F(TrellisFixture, MultipleMessageTypesWithIndividualCallbacks) {
   trellis::core::MessageConsumer<1, test::Test, test::TestTwo> inputs_{
       node_,
       {{"consumer_topic_1", "consumer_topic_2"}},
-      {[this](const test::Test& msg, const time::TimePoint&) {
+      {[this](const std::string& topic, const test::Test& msg, const time::TimePoint&) {
          ASSERT_EQ(receive_count_1, msg.id());
          ++receive_count_1;
        },
-       [this](const test::TestTwo& msg, const time::TimePoint&) {
+       [this](const std::string& topic, const test::TestTwo& msg, const time::TimePoint&) {
          ASSERT_FLOAT_EQ(receive_count_2, msg.foo() / 2.0);
          ++receive_count_2;
        }}};
@@ -77,11 +77,11 @@ TEST_F(TrellisFixture, MultipleMessageTypesWithIndividualCallbacksAndWatchdogs) 
   trellis::core::MessageConsumer<1, test::Test, test::TestTwo> inputs_{
       node_,
       {{"consumer_topic_1", "consumer_topic_2"}},
-      {[this](const test::Test& msg, const time::TimePoint&) {
+      {[this](const std::string& topic, const test::Test& msg, const time::TimePoint&) {
          ASSERT_EQ(receive_count_1, msg.id());
          ++receive_count_1;
        },
-       [this](const test::TestTwo& msg, const time::TimePoint&) {
+       [this](const std::string& topic, const test::TestTwo& msg, const time::TimePoint&) {
          ASSERT_FLOAT_EQ(receive_count_2, msg.foo() / 2.0);
          ++receive_count_2;
        }},

--- a/trellis/examples/subscriber/app.cpp
+++ b/trellis/examples/subscriber/app.cpp
@@ -9,12 +9,14 @@ using namespace trellis::core;
 App::App(const Node& node, const Config& config)
     : inputs_{node,
               {{config["examples"]["publisher"]["topic"].as<std::string>()}},
-              [this](const trellis::examples::proto::HelloWorld& msg, const time::TimePoint&) { NewMessage(msg); },
+              [this](const std::string& topic, const trellis::examples::proto::HelloWorld& msg,
+                     const time::TimePoint&) { NewMessage(topic, msg); },
               {{2000U}},
               {{[]() { Log::Warn("Watchdog tripped on inbound messages!"); }}}} {}
 
-void App::NewMessage(const trellis::examples::proto::HelloWorld& msg) {
-  Log::Info("Received message from {} with content {} and message number {}", msg.name(), msg.msg(), msg.id());
+void App::NewMessage(const std::string& topic, const trellis::examples::proto::HelloWorld& msg) {
+  Log::Info("Received message on topic {} from {} with content {} and message number {}", topic, msg.name(), msg.msg(),
+            msg.id());
 }
 
 }  // namespace subscriber

--- a/trellis/examples/subscriber/app.hpp
+++ b/trellis/examples/subscriber/app.hpp
@@ -14,7 +14,7 @@ class App {
   App(const trellis::core::Node& node, const trellis::core::Config& config);
 
  private:
-  void NewMessage(const trellis::examples::proto::HelloWorld& msg);
+  void NewMessage(const std::string& topic, const trellis::examples::proto::HelloWorld& msg);
 
   trellis::core::MessageConsumer<1, trellis::examples::proto::HelloWorld> inputs_;
 };


### PR DESCRIPTION
In some cases it may be nice to know which topic your inbound message came from if you have multiple topics with the same message type on it. For example, even if the message type is the same, you may want to handle the message differently based on which topic it came from.

Message consumer will now pass the topic to the per-message callbacks.