### PR TITLE
Fix Race Condition in Timer Test

### DIFF
--- a/trellis/BUILD
+++ b/trellis/BUILD
@@ -119,17 +119,59 @@ cc_library(
 )
 
 cc_test(
-    name = "test_core",
+    name = "test_core_message_consumer",
     srcs = [
         "core/test/test_message_consumer.cpp",
-        "core/test/test_node.cpp",
-        "core/test/test_pubsub.cpp",
-        "core/test/test_service.cpp",
-        "core/test/test_timer.cpp",
     ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_fixture",
         ":test_proto",
+    ],
+)
+
+cc_test(
+    name = "test_core_node",
+    srcs = [
+        "core/test/test_node.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test_fixture",
+    ],
+)
+
+cc_test(
+    name = "test_core_pubsub",
+    srcs = [
+        "core/test/test_pubsub.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test_fixture",
+        ":test_proto",
+    ],
+)
+
+cc_test(
+    name = "test_core_service",
+    srcs = [
+        "core/test/test_service.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test_fixture",
+        ":test_proto",
+    ],
+)
+
+cc_test(
+    name = "test_core_timer",
+    srcs = [
+        "core/test/test_timer.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test_fixture",
     ],
 )

--- a/trellis/core/test/test_timer.cpp
+++ b/trellis/core/test/test_timer.cpp
@@ -54,11 +54,11 @@ TEST_F(TrellisFixture, OneShotTimerReset) {
 
   auto timer = node_.CreateOneShotTimer(30, []() { ++fire_count; });
   ASSERT_EQ(timer->Expired(), false);
-  // Keep resetting the timer for longer than it was originally set to expire
+  // Keep rapidly resetting the timer and let more time pass than the timer was
+  // originally set for
   for (unsigned i = 0; i < 100; ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     timer->Reset();
-    ASSERT_EQ(timer->Expired(), false);
   }
 
   // Now it should still fire once after we wait

--- a/trellis/core/timer.hpp
+++ b/trellis/core/timer.hpp
@@ -86,7 +86,7 @@ class TimerImpl {
   const unsigned interval_ms_;
   const unsigned delay_ms_;
   asio::steady_timer timer_;
-  bool expired_{true};
+  std::atomic<bool> expired_{true};
 };
 
 using Timer = std::shared_ptr<TimerImpl>;


### PR DESCRIPTION
* Fixes a race condition causing flaky unit test
* More granular cc_test definitions
* Using atomic bool for thread safety