### PR TITLE
Dynamic Subscriber Refactor

### DIFF
--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -137,6 +137,8 @@ class Node {
    *
    * @param topic the topic name to subscribe to
    * @param callback the function to call for every new inbound message
+   * @param watchdog_timeout_ms optional timeout in milliseconds for a watchdog
+   * @param watchdog_callback optional watchdog callback to monitor timeouts
    *
    * Note that the callback will receive a generic `google::protobuf::Message` and must have a way
    * to determine how to interpret the message

--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -93,15 +93,15 @@ class Node {
    *
    * @return a subscriber handle
    */
-  template <typename MSG_T>
-  Subscriber<MSG_T> CreateSubscriber(std::string topic, std::function<void(const MSG_T&)> callback,
-                                 std::optional<unsigned> watchdog_timeout_ms = {},
-                                 typename SubscriberImpl<MSG_T>::WatchdogCallback watchdog_callback = {}) const {
+  template <typename MSG_T, typename ECAL_SUB_T = eCAL::protobuf::CSubscriber<MSG_T>>
+  Subscriber<MSG_T, ECAL_SUB_T> CreateSubscriber(
+      std::string topic, std::function<void(const MSG_T&)> callback, std::optional<unsigned> watchdog_timeout_ms = {},
+      typename SubscriberImpl<MSG_T, ECAL_SUB_T>::WatchdogCallback watchdog_callback = {}) const {
     if (watchdog_timeout_ms && watchdog_callback) {
-      return std::make_shared<SubscriberImpl<MSG_T>>(topic.c_str(), callback, *watchdog_timeout_ms, watchdog_callback,
-                                                 GetEventLoop());
+      return std::make_shared<SubscriberImpl<MSG_T, ECAL_SUB_T>>(topic.c_str(), callback, *watchdog_timeout_ms,
+                                                                 watchdog_callback, GetEventLoop());
     } else {
-      return std::make_shared<SubscriberImpl<MSG_T>>(topic.c_str(), callback);
+      return std::make_shared<SubscriberImpl<MSG_T, ECAL_SUB_T>>(topic.c_str(), callback);
     }
   }
 
@@ -143,10 +143,13 @@ class Node {
    *
    * @return a subscriber handle
    */
-  DynamicSubscriber CreateDynamicSubscriber(std::string topic,
-                                            std::function<void(const google::protobuf::Message&)> callback) {
-    return std::make_shared<SubscriberImpl<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>>(
-        topic.c_str(), callback);
+  DynamicSubscriber CreateDynamicSubscriber(
+      std::string topic, std::function<void(const google::protobuf::Message&)> callback,
+      std::optional<unsigned> watchdog_timeout_ms = {},
+      typename SubscriberImpl<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>::WatchdogCallback
+          watchdog_callback = {}) {
+    return CreateSubscriber<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>(
+        topic, callback, watchdog_timeout_ms, watchdog_callback);
   }
 
   /**

--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -74,9 +74,9 @@ class Node {
    *
    * @return a handle to a publisher instance
    */
-  template <typename T>
-  Publisher<T> CreatePublisher(std::string topic) const {
-    return std::make_shared<PublisherClass<T>>(topic.c_str());
+  template <typename MSG_T>
+  Publisher<MSG_T> CreatePublisher(std::string topic) const {
+    return std::make_shared<PublisherClass<MSG_T>>(topic.c_str());
   }
 
   /**
@@ -93,15 +93,15 @@ class Node {
    *
    * @return a subscriber handle
    */
-  template <typename T>
-  Subscriber<T> CreateSubscriber(std::string topic, std::function<void(const T&)> callback,
+  template <typename MSG_T>
+  Subscriber<MSG_T> CreateSubscriber(std::string topic, std::function<void(const MSG_T&)> callback,
                                  std::optional<unsigned> watchdog_timeout_ms = {},
-                                 typename SubscriberImpl<T>::WatchdogCallback watchdog_callback = {}) const {
+                                 typename SubscriberImpl<MSG_T>::WatchdogCallback watchdog_callback = {}) const {
     if (watchdog_timeout_ms && watchdog_callback) {
-      return std::make_shared<SubscriberImpl<T>>(topic.c_str(), callback, *watchdog_timeout_ms, watchdog_callback,
+      return std::make_shared<SubscriberImpl<MSG_T>>(topic.c_str(), callback, *watchdog_timeout_ms, watchdog_callback,
                                                  GetEventLoop());
     } else {
-      return std::make_shared<SubscriberImpl<T>>(topic.c_str(), callback);
+      return std::make_shared<SubscriberImpl<MSG_T>>(topic.c_str(), callback);
     }
   }
 

--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -145,12 +145,8 @@ class Node {
    */
   DynamicSubscriber CreateDynamicSubscriber(std::string topic,
                                             std::function<void(const google::protobuf::Message&)> callback) {
-    DynamicSubscriber subscriber = std::make_shared<DynamicSubscriberClass>(topic);
-    // TODO(bsirang) consider passing time_ and clock_ to user
-    auto callback_wrapper = [callback](const char* topic_name_, const google::protobuf::Message& msg_,
-                                       long long time_) { callback(msg_); };
-    subscriber->AddReceiveCallback(callback_wrapper);
-    return subscriber;
+    return std::make_shared<SubscriberImpl<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>>(
+        topic.c_str(), callback);
   }
 
   /**

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -103,8 +103,8 @@ class SubscriberImpl {
   EventLoop ev_loop_;
 };
 
-template <typename MSG_T>
-using Subscriber = std::shared_ptr<SubscriberImpl<MSG_T>>;
+template <typename MSG_T, typename ECAL_SUB_T = eCAL::protobuf::CSubscriber<MSG_T>>
+using Subscriber = std::shared_ptr<SubscriberImpl<MSG_T, ECAL_SUB_T>>;
 
 using DynamicSubscriberClass = SubscriberImpl<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>;
 using DynamicSubscriber = std::shared_ptr<DynamicSubscriberClass>;

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -106,8 +106,7 @@ class SubscriberImpl {
 template <typename MSG_T>
 using Subscriber = std::shared_ptr<SubscriberImpl<MSG_T>>;
 
-using DynamicSubscriberClass = eCAL::protobuf::CDynamicSubscriber;
-// using DynamicSubscriberClass = SubscriberImpl<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>;
+using DynamicSubscriberClass = SubscriberImpl<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>;
 using DynamicSubscriber = std::shared_ptr<DynamicSubscriberClass>;
 
 }  // namespace core

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -45,6 +45,13 @@ class SubscriberImpl {
   using RawCallback =
       std::function<void(const char* topic_name_, const MSG_T& msg_, long long time_, long long clock_, long long id_)>;
 
+  /*
+   * To support both dynamic subscribers (specialized with `google::protobuf::Message`) as well as specific message
+   * types, we need to use SFINAE (a. la. `std::enable_if_t`) to allow the compiler to select the correct
+   * `SetCallbackWithoutWatchdog` and `SetCallbackWithWatchdog` overloads based on whether or not we're using the
+   * `google::protobuf::Message` type. This is because unfortunately there's a special case because eCAL's dynamic
+   * subscriber callbacks use a slightly different function signature.
+   */
   template <class FOO = MSG_T, std::enable_if_t<!std::is_same<FOO, google::protobuf::Message>::value>* = nullptr>
   void SetCallbackWithoutWatchdog(Callback callback) {
     auto callback_wrapper = [callback](const char* topic_name_, const MSG_T& msg_, long long time_, long long clock_,


### PR DESCRIPTION
This PR refactors `trellis::core::SubscriberImpl` such that it can be used as a generic dynamic subscriber (with `MSG_T = google::protobuf::Message`). Now `DynamicSubscriber` is no longer a direct alias of eCAL's `eCAL::protobuf::CDynamicSubscriber`. Instead it is an alias of `SubscriberImpl` specialized with `google::protobuf::Message`

This allows code reuse of `trellis::core::SubscriberImpl` and associated functionality, such as watchdog timeouts, for the case of dynamic subscribers.