### PR TITLE
Subscriber Callback Max Frequency (Rate Throttle)

### DIFF
--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -69,7 +69,7 @@ class Node {
   /**
    * CreatePublisher create a new handle for a publisher
    *
-   * @tparam T the message type that will be published by this handle
+   * @tparam MSG_T the message type that will be published by this handle
    * @param topic the topic name to publish to
    *
    * @return a handle to a publisher instance
@@ -82,7 +82,8 @@ class Node {
   /**
    * CreateSubscriber create a new handle for a subscriber
    *
-   * @tparam the message type that we expect to receive from the publisher
+   * @tparam MSG_T the message type that we expect to receive from the publisher
+   * @tparam ECAL_SUB_T the eCAL subscriber primitive to use (will almost always be default)
    * @param topic the topic name to subscribe to
    * @param callback the function to call for every new inbound message
    * @param watchdog_timeout_ms optional timeout in milliseconds for a watchdog

--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -87,6 +87,7 @@ class Node {
    * @param callback the function to call for every new inbound message
    * @param watchdog_timeout_ms optional timeout in milliseconds for a watchdog
    * @param watchdog_callback optional watchdog callback to monitor timeouts
+   * @param max_frequency optional maximum frequency to throttle the subscriber callback
    *
    * NOTE: Both watchdog_timeout_ms and watchdog_callback must be specified in
    * order to enable watchdog monitoring.
@@ -96,8 +97,16 @@ class Node {
   template <typename MSG_T, typename ECAL_SUB_T = eCAL::protobuf::CSubscriber<MSG_T>>
   Subscriber<MSG_T, ECAL_SUB_T> CreateSubscriber(
       std::string topic, std::function<void(const MSG_T&)> callback, std::optional<unsigned> watchdog_timeout_ms = {},
-      typename SubscriberImpl<MSG_T, ECAL_SUB_T>::WatchdogCallback watchdog_callback = {}) const {
-    if (watchdog_timeout_ms && watchdog_callback) {
+      typename SubscriberImpl<MSG_T, ECAL_SUB_T>::WatchdogCallback watchdog_callback = {},
+      std::optional<double> max_frequency = {}) const {
+    const bool do_watchdog = static_cast<bool>(watchdog_timeout_ms && watchdog_callback);
+    const bool do_throttle = static_cast<bool>(max_frequency);
+    if (do_throttle && do_watchdog) {
+      return std::make_shared<SubscriberImpl<MSG_T, ECAL_SUB_T>>(topic.c_str(), callback, *watchdog_timeout_ms,
+                                                                 watchdog_callback, GetEventLoop(), *max_frequency);
+    } else if (do_throttle && !do_watchdog) {
+      return std::make_shared<SubscriberImpl<MSG_T, ECAL_SUB_T>>(topic.c_str(), callback, *max_frequency);
+    } else if (!do_throttle && do_watchdog) {
       return std::make_shared<SubscriberImpl<MSG_T, ECAL_SUB_T>>(topic.c_str(), callback, *watchdog_timeout_ms,
                                                                  watchdog_callback, GetEventLoop());
     } else {
@@ -139,6 +148,7 @@ class Node {
    * @param callback the function to call for every new inbound message
    * @param watchdog_timeout_ms optional timeout in milliseconds for a watchdog
    * @param watchdog_callback optional watchdog callback to monitor timeouts
+   * @param max_frequency optional maximum frequency to throttle the subscriber callback
    *
    * Note that the callback will receive a generic `google::protobuf::Message` and must have a way
    * to determine how to interpret the message
@@ -149,9 +159,10 @@ class Node {
       std::string topic, std::function<void(const google::protobuf::Message&)> callback,
       std::optional<unsigned> watchdog_timeout_ms = {},
       typename SubscriberImpl<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>::WatchdogCallback
-          watchdog_callback = {}) {
+          watchdog_callback = {},
+      std::optional<double> max_frequency = {}) {
     return CreateSubscriber<google::protobuf::Message, eCAL::protobuf::CDynamicSubscriber>(
-        topic, callback, watchdog_timeout_ms, watchdog_callback);
+        topic, callback, watchdog_timeout_ms, watchdog_callback, max_frequency);
   }
 
   /**

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -42,6 +42,21 @@ class SubscriberImpl {
     SetCallbackWithWatchdog(callback, watchdog_callback, watchdog_timeout_ms, event_loop);
   }
 
+  /**
+   * SetMaxFrequencyThrottle set the maximum callback frequency for this subscriber
+   *
+   * This is useful in cases where the subscriber wants to process inbound messages
+   * at a rate slower than the nominal publish rate. This rate can be changed
+   * dynamically, which can be helpful in use cases where a downstream client
+   * may want to request data at a specified rate at runtime.
+   *
+   * @param frequency The upper limit on receive frequency (in Hz)
+   */
+  void SetMaxFrequencyThrottle(double frequency) {
+    const unsigned interval_ms = static_cast<unsigned>(1000 / frequency);
+    *rate_throttle_interval_ms_ = interval_ms;
+  }
+
  private:
   using RawCallback =
       std::function<void(const char* topic_name_, const MSG_T& msg_, long long time_, long long clock_, long long id_)>;
@@ -124,7 +139,7 @@ class SubscriberImpl {
 
   ECAL_SUB_T ecal_sub_;
   EventLoop ev_loop_;
-  const std::optional<unsigned> rate_throttle_interval_ms_;
+  std::optional<std::atomic<unsigned>> rate_throttle_interval_ms_;
   trellis::core::time::TimePoint last_sent_;
 };
 

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -171,11 +171,11 @@ class SubscriberImpl {
   }
 
   void CallbackWrapperLogic(const MSG_T& msg, const Callback& callback) {
-    if (rate_throttle_interval_ms_) {
+    const unsigned interval_ms = rate_throttle_interval_ms_.load();
+    if (interval_ms) {
       // throttle callback
       const bool enough_time_elapsed =
-          std::chrono::duration_cast<std::chrono::milliseconds>(time::now() - last_sent_).count() >
-          rate_throttle_interval_ms_;
+          std::chrono::duration_cast<std::chrono::milliseconds>(time::now() - last_sent_).count() > interval_ms;
       if (enough_time_elapsed) {
         callback(msg);
         last_sent_ = trellis::core::time::now();

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -32,14 +32,57 @@ class SubscriberImpl {
  public:
   using Callback = std::function<void(const MSG_T&)>;
   using WatchdogCallback = std::function<void(void)>;
+
+  /**
+   * Construct a subscriber for a given topic
+   *
+   * @param topic the topic string to subscribe to
+   * @param callback the callback function to receive messages on
+   */
   SubscriberImpl(const std::string& topic, Callback callback) : ecal_sub_{topic} {
     SetCallbackWithoutWatchdog(callback);
   }
 
+  /**
+   * Construct a subscriber for a given topic with a rate throttle
+   *
+   * @param topic the topic string to subscribe to
+   * @param callback the callback function to receive messages on
+   * @param max_frequency the maximum frequency in which the callback may be called
+   */
+  SubscriberImpl(const std::string& topic, Callback callback, double max_frequency) : SubscriberImpl(topic, callback) {
+    SetMaxFrequencyThrottle(max_frequency);
+  }
+
+  /**
+   * Construct a subscriber for a given topic with a watchdog timer
+   *
+   * @param topic the topic string to subscribe to
+   * @param callback the callback function to receive messages on
+   * @param watchdog_timeout_ms the amount of time in milliseconds in between messages that will trigger the watchdog
+   * @param watchdog_callback the function to call when the watchdog fires
+   * @param event_loop the event loop handle in which to run the watchdog on
+   */
   SubscriberImpl(const std::string& topic, Callback callback, unsigned watchdog_timeout_ms,
                  WatchdogCallback watchdog_callback, EventLoop event_loop)
       : ecal_sub_{topic} {
     SetCallbackWithWatchdog(callback, watchdog_callback, watchdog_timeout_ms, event_loop);
+  }
+
+  /**
+   * Construct a subscriber for a given topic with a watchdog timer and rate throttle
+   *
+   * @param topic the topic string to subscribe to
+   * @param callback the callback function to receive messages on
+   * @param watchdog_timeout_ms the amount of time in milliseconds in between messages that will trigger the watchdog
+   * @param watchdog_callback the function to call when the watchdog fires
+   * @param event_loop the event loop handle in which to run the watchdog on
+   * @param max_frequency the maximum frequency in which the callback may be called
+   */
+  SubscriberImpl(const std::string& topic, Callback callback, unsigned watchdog_timeout_ms,
+                 WatchdogCallback watchdog_callback, EventLoop event_loop, double max_frequency)
+      : SubscriberImpl(topic, callback, watchdog_timeout_ms, watchdog_callback, event_loop) {
+    SetMaxFrequencyThrottle(max_frequency);
   }
 
   /**
@@ -53,8 +96,12 @@ class SubscriberImpl {
    * @param frequency The upper limit on receive frequency (in Hz)
    */
   void SetMaxFrequencyThrottle(double frequency) {
-    const unsigned interval_ms = static_cast<unsigned>(1000 / frequency);
-    *rate_throttle_interval_ms_ = interval_ms;
+    if (frequency != 0.0) {
+      const unsigned interval_ms = static_cast<unsigned>(1000 / frequency);
+      if (interval_ms != 0) {
+        *rate_throttle_interval_ms_ = interval_ms;
+      }
+    }
   }
 
  private:

--- a/trellis/core/test/test_pubsub.cpp
+++ b/trellis/core/test/test_pubsub.cpp
@@ -116,7 +116,7 @@ TEST_F(TrellisFixture, SubscriberThrottle) {
   auto sub = node_.CreateSubscriber<test::Test>(
       "test_throttle_topic",
       [](const test::Test& msg) {
-        ASSERT_EQ(msg.id() >= receive_count, true);
+        ASSERT_TRUE(msg.id() >= receive_count);
         ++receive_count;
       },
       {}, {}, 100.0);
@@ -132,8 +132,13 @@ TEST_F(TrellisFixture, SubscriberThrottle) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     ++sent_count;
   }
-  ASSERT_EQ(receive_count > 0, true);
-  ASSERT_EQ(receive_count <= 3, true);
-  ASSERT_EQ(sent_count > 0, true);
-  ASSERT_EQ(sent_count > receive_count, true);
+
+  ASSERT_TRUE(sent_count > 0);
+
+  // We should have received some
+  ASSERT_TRUE(receive_count > 0 && receive_count <= 3);
+  ASSERT_TRUE(receive_count <= 3);
+
+  // ...and it should be less than we sent
+  ASSERT_TRUE(sent_count > receive_count);
 }

--- a/trellis/core/test/test_pubsub.cpp
+++ b/trellis/core/test/test_pubsub.cpp
@@ -107,3 +107,33 @@ TEST_F(TrellisFixture, SubscriberWatchdogTimeout) {
   ASSERT_EQ(receive_count, 3U);
   ASSERT_EQ(watchdog_count, 2U);
 }
+
+TEST_F(TrellisFixture, SubscriberThrottle) {
+  static unsigned receive_count{0};
+  static unsigned sent_count{0};
+
+  auto pub = node_.CreatePublisher<test::Test>("test_throttle_topic");
+  auto sub = node_.CreateSubscriber<test::Test>(
+      "test_throttle_topic",
+      [](const test::Test& msg) {
+        ASSERT_EQ(msg.id() >= receive_count, true);
+        ++receive_count;
+      },
+      {}, {}, 100.0);
+
+  StartRunnerThread();
+  WaitForDiscovery();
+
+  for (unsigned i = 0; i < 20U; ++i) {
+    test::Test test_msg;
+    test_msg.set_id(i);
+    test_msg.set_msg("hello world");
+    pub->Send(test_msg);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    ++sent_count;
+  }
+  ASSERT_EQ(receive_count > 0, true);
+  ASSERT_EQ(receive_count <= 3, true);
+  ASSERT_EQ(sent_count > 0, true);
+  ASSERT_EQ(sent_count > receive_count, true);
+}


### PR DESCRIPTION
Adds support for specifying a maximum frequency to throttle the rate in which the subscriber may call the inbound message callback