### PR TITLE
Set max_frequency variables to max_frequency_hz

### DIFF
--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -48,10 +48,10 @@ class SubscriberImpl {
    *
    * @param topic the topic string to subscribe to
    * @param callback the callback function to receive messages on
-   * @param max_frequency the maximum frequency in which the callback may be called
+   * @param max_frequency the maximum frequency (in Hz) in which the callback may be called
    */
-  SubscriberImpl(const std::string& topic, Callback callback, double max_frequency) : SubscriberImpl(topic, callback) {
-    SetMaxFrequencyThrottle(max_frequency);
+  SubscriberImpl(const std::string& topic, Callback callback, double max_frequency_hz) : SubscriberImpl(topic, callback) {
+    SetMaxFrequencyThrottle(max_frequency_hz);
   }
 
   /**
@@ -77,12 +77,12 @@ class SubscriberImpl {
    * @param watchdog_timeout_ms the amount of time in milliseconds in between messages that will trigger the watchdog
    * @param watchdog_callback the function to call when the watchdog fires
    * @param event_loop the event loop handle in which to run the watchdog on
-   * @param max_frequency the maximum frequency in which the callback may be called
+   * @param max_frequency the maximum frequency (in Hz) in which the callback may be called
    */
   SubscriberImpl(const std::string& topic, Callback callback, unsigned watchdog_timeout_ms,
-                 WatchdogCallback watchdog_callback, EventLoop event_loop, double max_frequency)
+                 WatchdogCallback watchdog_callback, EventLoop event_loop, double max_frequency_hz)
       : SubscriberImpl(topic, callback, watchdog_timeout_ms, watchdog_callback, event_loop) {
-    SetMaxFrequencyThrottle(max_frequency);
+    SetMaxFrequencyThrottle(max_frequency_hz);
   }
 
   /**
@@ -95,9 +95,9 @@ class SubscriberImpl {
    *
    * @param frequency The upper limit on receive frequency (in Hz)
    */
-  void SetMaxFrequencyThrottle(double frequency) {
-    if (frequency != 0.0) {
-      const unsigned interval_ms = static_cast<unsigned>(1000 / frequency);
+  void SetMaxFrequencyThrottle(double frequency_hz) {
+    if (frequency_hz != 0.0) {
+      const unsigned interval_ms = static_cast<unsigned>(1000 / frequency_hz);
 
       if (interval_ms != 0) {
         rate_throttle_interval_ms_ = interval_ms;

--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -50,7 +50,8 @@ class SubscriberImpl {
    * @param callback the callback function to receive messages on
    * @param max_frequency the maximum frequency (in Hz) in which the callback may be called
    */
-  SubscriberImpl(const std::string& topic, Callback callback, double max_frequency_hz) : SubscriberImpl(topic, callback) {
+  SubscriberImpl(const std::string& topic, Callback callback, double max_frequency_hz)
+      : SubscriberImpl(topic, callback) {
     SetMaxFrequencyThrottle(max_frequency_hz);
   }
 


### PR DESCRIPTION
Took me a while to hunt down which units the variable was in. I figured I'd add it to the docstring / variable name.