### PR TITLE
trellis::core::TimePointToSeconds() scaling bugfix

### DIFF
--- a/trellis/BUILD
+++ b/trellis/BUILD
@@ -175,3 +175,15 @@ cc_test(
         ":test_fixture",
     ],
 )
+
+cc_test(
+    name = "test_core_time",
+    srcs = [
+        "core/test/test_time.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":trellis_core_ecal",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/trellis/core/test/test_time.cpp
+++ b/trellis/core/test/test_time.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Agtonomy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "trellis/core/time.hpp"
+
+using namespace trellis::core;
+
+TEST(TrellisTimeAPI, SecondsConversion) {
+  time::TimePoint start(std::chrono::milliseconds(500));
+  time::TimePoint end(std::chrono::milliseconds(1000));
+
+  const double start_secs = time::TimePointToSeconds(start);
+  const double end_secs = time::TimePointToSeconds(end);
+
+  const double dt = end_secs - start_secs;
+
+  ASSERT_TRUE(end_secs > start_secs);
+  ASSERT_TRUE(dt == 0.5);
+}

--- a/trellis/core/time.hpp
+++ b/trellis/core/time.hpp
@@ -37,7 +37,10 @@ inline TimePoint Now() { return eCAL::Time::ecal_clock::now(); }
  * @param tp the timepoint to convert
  * @return the equivalent value in seconds
  */
-inline double TimePointToSeconds(const TimePoint& tp) { return (tp.time_since_epoch().count() / 1000.0); }
+inline double TimePointToSeconds(const TimePoint& tp) {
+  return (tp.time_since_epoch().count() *
+          (static_cast<double>(TimePoint::period::num) / static_cast<double>(TimePoint::period::den)));
+}
 
 /**
  * NewInSeconds Get the current time in seconds


### PR DESCRIPTION
Properly scales the time since epoch in seconds.
Adds a unit test to validate the fix.