### PR TITLE
Examples - Add Initial Delay for Publish / Service Call

### DIFF
--- a/trellis/examples/config.yml
+++ b/trellis/examples/config.yml
@@ -5,3 +5,4 @@ examples:
   service:
     interval_ms: 2000
     timeout_ms: 100
+    initial_delay_ms: 2000

--- a/trellis/examples/config.yml
+++ b/trellis/examples/config.yml
@@ -2,6 +2,7 @@ examples:
   publisher:
     topic: hello_world
     interval_ms: 1000
+    initial_delay_ms: 2000
   service:
     interval_ms: 2000
     timeout_ms: 100

--- a/trellis/examples/publisher/app.cpp
+++ b/trellis/examples/publisher/app.cpp
@@ -9,15 +9,18 @@ using namespace trellis::core;
 App::App(const Node& node, const Config& config)
     : publisher_{node.CreatePublisher<trellis::examples::proto::HelloWorld>(
           config["examples"]["publisher"]["topic"].as<std::string>())},
-      timer_{node.CreateTimer(config["examples"]["publisher"]["interval_ms"].as<unsigned>(), [this]() { Tick(); })} {}
+      timer_{node.CreateTimer(
+          config["examples"]["publisher"]["interval_ms"].as<unsigned>(), [this]() { Tick(); },
+          config["examples"]["publisher"]["initial_delay_ms"].as<unsigned>())} {}
 
 void App::Tick() {
-  Log::Info("Publishing message number {}", send_count_);
+  const unsigned msg_number = send_count_++;
+  Log::Info("Publishing message number {}", msg_number);
 
   trellis::examples::proto::HelloWorld msg;
   msg.set_name("Publisher Example");
   msg.set_msg("Hello World!");
-  msg.set_id(++send_count_);
+  msg.set_id(msg_number);
   publisher_->Send(msg);
 }
 

--- a/trellis/examples/service_client/app.cpp
+++ b/trellis/examples/service_client/app.cpp
@@ -9,14 +9,12 @@ using namespace trellis::examples::proto;
 
 App::App(const Node& node, const Config& config)
     : client_{node.CreateServiceClient<AdditionService>()},
-      timer_{node.CreateTimer(config["examples"]["service"]["interval_ms"].as<unsigned>(), [this]() { Tick(); })},
+      timer_{node.CreateTimer(
+          config["examples"]["service"]["interval_ms"].as<unsigned>(), [this]() { Tick(); },
+          config["examples"]["service"]["initial_delay_ms"].as<unsigned>())},
       call_timeout_ms_{config["examples"]["service"]["timeout_ms"].as<unsigned>()} {}
 
 void App::HandleResponse(ServiceCallStatus status, const AdditionResponse* resp) {
-  if (!resp) {
-    Log::Error("Request failed!");
-    return;
-  }
   if (status == ServiceCallStatus::kFailure) {
     Log::Error("Request responded with failure!");
   } else if (status == ServiceCallStatus::kTimedOut) {


### PR DESCRIPTION
Also includes a couple small fixes:
- off-by-one error on message ID for publisher
- stale if statement was masking timeout error check on service call