### PR TITLE
Add nano and milli seconds helpers for TimePoint

### DIFF
--- a/trellis/core/test/test_time.cpp
+++ b/trellis/core/test/test_time.cpp
@@ -40,11 +40,24 @@ TEST(TrellisTimeAPI, Nanoseconds) {
   time::TimePoint start(std::chrono::milliseconds(500));
   time::TimePoint end(std::chrono::milliseconds(1000));
 
-  const double start_nanos = time::TimePointToNanoSeconds(start);
-  const double end_nanos = time::TimePointToNanoSeconds(end);
+  const double start_nanos = time::TimePointToNanoseconds(start);
+  const double end_nanos = time::TimePointToNanoseconds(end);
 
   const double dt = end_nanos - start_nanos;
 
   ASSERT_TRUE(end_nanos > start_nanos);
   ASSERT_TRUE(dt == 5e8);
+}
+
+TEST(TrellisTimeAPI, Milliseconds) {
+  time::TimePoint start(std::chrono::milliseconds(500));
+  time::TimePoint end(std::chrono::milliseconds(1000));
+
+  const double start_millis = time::TimePointToMilliseconds(start);
+  const double end_millis = time::TimePointToMilliseconds(end);
+
+  const double dt = end_millis - start_millis;
+
+  ASSERT_TRUE(end_millis > start_millis);
+  ASSERT_TRUE(dt == 500);
 }

--- a/trellis/core/test/test_time.cpp
+++ b/trellis/core/test/test_time.cpp
@@ -35,3 +35,16 @@ TEST(TrellisTimeAPI, SecondsConversion) {
   ASSERT_TRUE(end_secs > start_secs);
   ASSERT_TRUE(dt == 0.5);
 }
+
+TEST(TrellisTimeAPI, Nanoseconds) {
+  time::TimePoint start(std::chrono::milliseconds(500));
+  time::TimePoint end(std::chrono::milliseconds(1000));
+
+  const double start_nanos = time::TimePointToNanoSeconds(start);
+  const double end_nanos = time::TimePointToNanoSeconds(end);
+
+  const double dt = end_nanos - start_nanos;
+
+  ASSERT_TRUE(end_nanos > start_nanos);
+  ASSERT_TRUE(dt == 5e8);
+}

--- a/trellis/core/time.hpp
+++ b/trellis/core/time.hpp
@@ -49,19 +49,34 @@ inline double TimePointToSeconds(const TimePoint& tp) {
 inline double NowInSeconds() { return TimePointToSeconds(Now()); }
 
 /**
- * TimePointToNanoSeconds Convert a timepoint to nanoseconds
+ * TimePointToNanoseconds Convert a timepoint to nanoseconds
  * @param tp the timepoint to convert
  * @return the equivalent value in nanoseconds
  */
-inline unsigned long long TimePointToNanoSeconds(const TimePoint& tp) {
+inline unsigned long long TimePointToNanoseconds(const TimePoint& tp) {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
 }
 
 /**
- * NowInNanoSeconds Get the current time in nanoseconds
+ * NowInNanoseconds Get the current time in nanoseconds
  * @return a the time in nanoseconds since Unix epoch as an unsigned long long
  */
-inline unsigned long long NowInNanoSeconds() { return TimePointToNanoSeconds(Now()); }
+inline unsigned long long NowInNanoseconds() { return TimePointToNanoseconds(Now()); }
+
+/**
+ * TimePointToMilliseconds Convert a timepoint to nanoseconds
+ * @param tp the timepoint to convert
+ * @return the equivalent value in nanoseconds
+ */
+inline unsigned long long TimePointToMilliseconds(const TimePoint& tp) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count();
+}
+
+/**
+ * NowInMilliseconds Get the current time in milliseconds
+ * @return a the time in milliseconds since Unix epoch as an unsigned long long
+ */
+inline unsigned long long NowInMilliseconds() { return TimePointToMilliseconds(Now()); }
 
 }  // namespace time
 }  // namespace core

--- a/trellis/core/time.hpp
+++ b/trellis/core/time.hpp
@@ -43,10 +43,25 @@ inline double TimePointToSeconds(const TimePoint& tp) {
 }
 
 /**
- * NewInSeconds Get the current time in seconds
+ * NowInSeconds Get the current time in seconds
  * @return a the time in seconds since Unix epoch as a floating point value
  */
 inline double NowInSeconds() { return TimePointToSeconds(Now()); }
+
+/**
+ * TimePointToNanoSeconds Convert a timepoint to nanoseconds
+ * @param tp the timepoint to convert
+ * @return the equivalent value in nanoseconds
+ */
+inline unsigned long long TimePointToNanoSeconds(const TimePoint& tp) {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
+}
+
+/**
+ * NowInNanoSeconds Get the current time in nanoseconds
+ * @return a the time in nanoseconds since Unix epoch as an unsigned long long
+ */
+inline unsigned long long NowInNanoSeconds() { return TimePointToNanoSeconds(Now()); }
 
 }  // namespace time
 }  // namespace core


### PR DESCRIPTION
Adds Timepoint helpers for quickly accessing nanoseconds and milliseconds since epoch.