### PR TITLE
Trellis CLI Topic Echo Whitespace and Verbose Options

### DIFF
--- a/trellis/core/node.cpp
+++ b/trellis/core/node.cpp
@@ -34,7 +34,7 @@ Node::Node(std::string name) : name_{name}, ev_loop_{CreateEventLoop()}, work_gu
 Node::~Node() { Stop(); }
 
 int Node::Run() {
-  Log::Info("{} node running...", name_);
+  Log::Debug("{} node running...", name_);
   while (ShouldRun()) {
     ev_loop_->run_for(std::chrono::milliseconds(500));
     // If the event loop was stopped, run_for will return immediately, so

--- a/trellis/tools/trellis-cli/topic/topic_echo_main.cpp
+++ b/trellis/tools/trellis-cli/topic/topic_echo_main.cpp
@@ -35,7 +35,8 @@ time::TimePoint last_echo_time_;
 int topic_echo_main(int argc, char* argv[]) {
   cxxopts::Options options(topic_echo_command.data(), topic_echo_command_desc.data());
   options.add_options()("t,topic", "topic name", cxxopts::value<std::string>())(
-      "r,rate", "max echo rate in hz", cxxopts::value<int>()->default_value("0"))("h,help", "print usage");
+      "r,rate", "max echo rate in hz", cxxopts::value<int>()->default_value("0"))(
+      "w,whitespace", "add whitespace to output")("v,verbose", "include non-essential output")("h,help", "print usage");
 
   auto result = options.parse(argc, argv);
   if (result.count("help") || !result.count("topic")) {
@@ -46,32 +47,39 @@ int topic_echo_main(int argc, char* argv[]) {
   const std::string topic = result["topic"].as<std::string>();
   const int rate = std::clamp(result["rate"].as<int>(), 0, 1000);
   unsigned throttle_interval_ms = (rate > 0) ? 1000.0 / static_cast<unsigned>(rate) : 0;
+  const bool add_whitespace = result.count("whitespace");
+  const bool verbose = result.count("verbose");
 
   Node node(root_command.data());
-  auto sub = node.CreateDynamicSubscriber(topic, [throttle_interval_ms](const google::protobuf::Message& msg) {
-    if (throttle_interval_ms != 0) {
-      auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time::Now() - last_echo_time_).count();
-      if (elapsed_ms <= throttle_interval_ms) {
-        return;  // rate throttle
-      }
-    }
-    // convert to JSON and print
-    std::string json;
-    google::protobuf::util::JsonPrintOptions json_options;
-    json_options.add_whitespace = true;
-    json_options.always_print_primitive_fields = true;
-    json_options.always_print_enums_as_ints = false;
-    json_options.preserve_proto_field_names = false;
-    auto r = google::protobuf::util::MessageToJsonString(msg, &json, json_options);
-    std::cout << json << std::endl;
-    last_echo_time_ = time::Now();
-  });
+  auto sub =
+      node.CreateDynamicSubscriber(topic, [throttle_interval_ms, add_whitespace](const google::protobuf::Message& msg) {
+        if (throttle_interval_ms != 0) {
+          auto elapsed_ms =
+              std::chrono::duration_cast<std::chrono::milliseconds>(time::Now() - last_echo_time_).count();
+          if (elapsed_ms <= throttle_interval_ms) {
+            return;  // rate throttle
+          }
+        }
+        // convert to JSON and print
+        std::string json;
+        google::protobuf::util::JsonPrintOptions json_options;
+        json_options.add_whitespace = add_whitespace;
+        json_options.always_print_primitive_fields = true;
+        json_options.always_print_enums_as_ints = false;
+        json_options.preserve_proto_field_names = false;
+        auto r = google::protobuf::util::MessageToJsonString(msg, &json, json_options);
+        std::cout << json << std::endl;
+        last_echo_time_ = time::Now();
+      });
 
-  std::cout << "Echoing messages on \"" << topic << "\"";
-  if (rate != 0) {
-    std::cout << " with max rate " << rate << " Hz";
+  if (verbose) {
+    std::cout << "Echoing messages on \"" << topic << "\"";
+    if (rate != 0) {
+      std::cout << " with max rate " << rate << " Hz";
+    }
+    std::cout << " and " << (add_whitespace ? "multi" : "one") << "-line output.";
+    std::cout << std::endl;
   }
-  std::cout << std::endl;
 
   node.Run();
   return 0;


### PR DESCRIPTION
Added a whitespace option to disable adding whitespace by default so that JSON output is single line only.
Added a verbose option to disable outputting non-essential output by default.

This makes it easy to pipe the output of topic echo to other programs that expect JSON only.