### PR TITLE
CLI Remove Workspace Name Dependency from BUILD Dep

### DIFF
--- a/trellis/tools/trellis-cli/BUILD
+++ b/trellis/tools/trellis-cli/BUILD
@@ -18,7 +18,7 @@ cc_binary(
     ],
     linkstatic = False,
     deps = [
-        "@//trellis",
+        "//trellis",
         "@cxxopts",
     ],
 )

--- a/trellis/tools/trellis-cli/BUILD
+++ b/trellis/tools/trellis-cli/BUILD
@@ -18,7 +18,7 @@ cc_binary(
     ],
     linkstatic = False,
     deps = [
+        "@//trellis",
         "@cxxopts",
-        "@trellis//trellis",
     ],
 )


### PR DESCRIPTION
This allows other workspaces which include trellis to be able to build the CLI target