### PR TITLE
Set visibility of trellis-cli to public

### DIFF
--- a/trellis/tools/trellis-cli/BUILD
+++ b/trellis/tools/trellis-cli/BUILD
@@ -17,6 +17,7 @@ cc_binary(
         "topic/topic_publish_main.cpp",
     ],
     linkstatic = False,
+    visibility = ["//visibility:public"],
     deps = [
         "//trellis",
         "@cxxopts",


### PR DESCRIPTION
I'm trying to depend on this target in a `filegroup` in my repo, but this isn't public visible.