### PR TITLE
Add ecal-sys-client-cli to //third_party/ecal.BUILD

### DIFF
--- a/third_party/ecal.BUILD
+++ b/third_party/ecal.BUILD
@@ -356,7 +356,6 @@ cc_library(
     deps = [
         ":ecal",
         ":ecal_parser",
-        "@fmt",
         "@spdlog",
     ],
 )

--- a/third_party/ecal.BUILD
+++ b/third_party/ecal.BUILD
@@ -349,17 +349,16 @@ cc_library(
         "app/sys/sys_client_core/src/proto_helpers.cpp",
         "app/sys/sys_client_core/src/task.cpp",
     ],
+    includes = [
+        "app/sys/sys_client_core/include",
+        "app/sys/sys_client_core/src",
+    ],
     deps = [
         ":ecal",
         ":ecal_parser",
-        "@fmt//:fmt",
-        "@spdlog//:spdlog",
-     ],
-     includes = [
-         "app/sys/sys_client_core/src",
-         "app/sys/sys_client_core/include",
-     ],
-
+        "@fmt",
+        "@spdlog",
+    ],
 )
 
 cc_library(
@@ -369,6 +368,6 @@ cc_library(
         "app/sys/sys_client_cli/src/ecal_sys_client_service.cpp",
         "app/sys/sys_client_cli/src/ecal_sys_client_service.h",
     ],
-    deps = [":sys_client_core"],
     visibility = ["//visibility:public"],
+    deps = [":sys_client_core"],
 )

--- a/third_party/ecal.BUILD
+++ b/third_party/ecal.BUILD
@@ -335,3 +335,40 @@ genrule(
         "EOF",
     ]),
 )
+
+cc_library(
+    name = "sys_client_core",
+    srcs = [
+        "app/sys/sys_client_core/include/sys_client_core/ecal_sys_client.h",
+        "app/sys/sys_client_core/include/sys_client_core/ecal_sys_client_defs.h",
+        "app/sys/sys_client_core/include/sys_client_core/ecal_sys_client_logger.h",
+        "app/sys/sys_client_core/include/sys_client_core/proto_helpers.h",
+        "app/sys/sys_client_core/include/sys_client_core/runner.h",
+        "app/sys/sys_client_core/include/sys_client_core/task.h",
+        "app/sys/sys_client_core/src/ecal_sys_client.cpp",
+        "app/sys/sys_client_core/src/proto_helpers.cpp",
+        "app/sys/sys_client_core/src/task.cpp",
+    ],
+    deps = [
+        ":ecal",
+        ":ecal_parser",
+        "@fmt//:fmt",
+        "@spdlog//:spdlog",
+     ],
+     includes = [
+         "app/sys/sys_client_core/src",
+         "app/sys/sys_client_core/include",
+     ],
+
+)
+
+cc_library(
+    name = "sys_client_cli",
+    srcs = [
+        "app/sys/sys_client_cli/src/ecal_sys_client_cli.cpp",
+        "app/sys/sys_client_cli/src/ecal_sys_client_service.cpp",
+        "app/sys/sys_client_cli/src/ecal_sys_client_service.h",
+    ],
+    deps = [":sys_client_core"],
+    visibility = ["//visibility:public"],
+)

--- a/trellis/tools/sys_client_cli/BUILD
+++ b/trellis/tools/sys_client_cli/BUILD
@@ -1,0 +1,7 @@
+cc_binary(
+    name = "sys_client_cli",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ecal//:sys_client_cli",
+    ],
+)


### PR DESCRIPTION
Add ecal-sys-client-cli to //third_party/ecal.BUILD

I followed your paradigm by specifying all required files ( instead of globs), and removing the prefix `ecal_` from the targets.
