### PR TITLE
Message Consumer Watchdog Callback API Update - Topic Name Argument

### DIFF
--- a/trellis/core/message_consumer.hpp
+++ b/trellis/core/message_consumer.hpp
@@ -59,7 +59,8 @@ class MessageConsumer {
   using SingleTopicArray = std::array<SingleTopic, sizeof...(Types)>;
   using TopicsArray = std::array<TopicsList, sizeof...(Types)>;
   using OptionalWatchdogTimeoutsArray = std::optional<std::array<unsigned, sizeof...(Types)>>;
-  using WatchdogCallbacksArray = std::array<std::function<void(void)>, sizeof...(Types)>;
+  using WatchdogCallback = std::function<void(void)>;
+  using WatchdogCallbacksArray = std::array<WatchdogCallback, sizeof...(Types)>;
   using OptionalMaxFrequencyArray = std::optional<std::array<double, sizeof...(Types)>>;
 
   /*

--- a/trellis/core/test/test_message_consumer.cpp
+++ b/trellis/core/test/test_message_consumer.cpp
@@ -90,7 +90,14 @@ TEST_F(TrellisFixture, MultipleMessageTypesWithIndividualCallbacksAndWatchdogs) 
          ++receive_count_2;
        }},
       {{50U, 100U}},
-      {{[]() { ++watchdog_count_1; }, []() { ++watchdog_count_2; }}}};
+      {{[](const std::string& topic) {
+          ++watchdog_count_1;
+          ASSERT_EQ(topic, "consumer_topic_1");
+        },
+        [](const std::string& topic) {
+          ++watchdog_count_2;
+          ASSERT_EQ(topic, "consumer_topic_2");
+        }}}};
 
   WaitForDiscovery();
 

--- a/trellis/examples/subscriber/app.cpp
+++ b/trellis/examples/subscriber/app.cpp
@@ -12,7 +12,7 @@ App::App(const Node& node, const Config& config)
               [this](const std::string& topic, const trellis::examples::proto::HelloWorld& msg,
                      const time::TimePoint&) { NewMessage(topic, msg); },
               {{2000U}},
-              {{[]() { Log::Warn("Watchdog tripped on inbound messages!"); }}}} {}
+              {{[](const std::string&) { Log::Warn("Watchdog tripped on inbound messages!"); }}}} {}
 
 void App::NewMessage(const std::string& topic, const trellis::examples::proto::HelloWorld& msg) {
   Log::Info("Received message on topic {} from {} with content {} and message number {}", topic, msg.name(), msg.msg(),


### PR DESCRIPTION
Before this change, in cases where we are using MessageConsumer to receives the same message type on multiple topics, we couldn't differentiate between which topic was actually triggering the watchdog.

Now we simply supply the topic when the watchdog trips