### PR TITLE
TimePointToSystemTime() API

### DIFF
--- a/trellis/core/test/test_time.cpp
+++ b/trellis/core/test/test_time.cpp
@@ -24,39 +24,39 @@
 using namespace trellis::core;
 
 TEST(TrellisTimeAPI, SecondsConversion) {
-  time::TimePoint start(std::chrono::milliseconds(500));
-  time::TimePoint end(std::chrono::milliseconds(1000));
+  const time::TimePoint start(std::chrono::milliseconds(500));
+  const time::TimePoint end(std::chrono::milliseconds(1000));
 
-  const double start_secs = time::TimePointToSeconds(start);
-  const double end_secs = time::TimePointToSeconds(end);
+  const auto start_secs = time::TimePointToSeconds(start);
+  const auto end_secs = time::TimePointToSeconds(end);
 
-  const double dt = end_secs - start_secs;
+  const auto dt = end_secs - start_secs;
 
   ASSERT_TRUE(end_secs > start_secs);
   ASSERT_TRUE(dt == 0.5);
 }
 
 TEST(TrellisTimeAPI, Nanoseconds) {
-  time::TimePoint start(std::chrono::milliseconds(500));
-  time::TimePoint end(std::chrono::milliseconds(1000));
+  const time::TimePoint start(std::chrono::milliseconds(500));
+  const time::TimePoint end(std::chrono::milliseconds(1000));
 
-  const double start_nanos = time::TimePointToNanoseconds(start);
-  const double end_nanos = time::TimePointToNanoseconds(end);
+  const auto start_nanos = time::TimePointToNanoseconds(start);
+  const auto end_nanos = time::TimePointToNanoseconds(end);
 
-  const double dt = end_nanos - start_nanos;
+  const auto dt = end_nanos - start_nanos;
 
   ASSERT_TRUE(end_nanos > start_nanos);
   ASSERT_TRUE(dt == 5e8);
 }
 
 TEST(TrellisTimeAPI, Milliseconds) {
-  time::TimePoint start(std::chrono::milliseconds(500));
-  time::TimePoint end(std::chrono::milliseconds(1000));
+  const time::TimePoint start(std::chrono::milliseconds(500));
+  const time::TimePoint end(std::chrono::milliseconds(1000));
 
-  const double start_millis = time::TimePointToMilliseconds(start);
-  const double end_millis = time::TimePointToMilliseconds(end);
+  const auto start_millis = time::TimePointToMilliseconds(start);
+  const auto end_millis = time::TimePointToMilliseconds(end);
 
-  const double dt = end_millis - start_millis;
+  const auto dt = end_millis - start_millis;
 
   ASSERT_TRUE(end_millis > start_millis);
   ASSERT_TRUE(dt == 500);
@@ -66,6 +66,8 @@ TEST(TrellisTimeAPI, SetSimTimeWhileDisabled) {
   trellis::core::time::TimePoint timepoint{std::chrono::milliseconds(1500)};
   ASSERT_THROW(trellis::core::time::SetSimulatedTime(timepoint), std::runtime_error);
 }
+
+// All the tests following this one have simulated clock enabled
 
 TEST(TrellisTimeAPI, EnableSimTime) {
   ASSERT_FALSE(trellis::core::time::IsSimulatedClockEnabled());
@@ -82,7 +84,7 @@ TEST(TrellisTimeAPI, EnableSimTime) {
 }
 
 TEST(TrellisTimeAPI, SetSimTime) {
-  auto now = trellis::core::time::Now();
+  const auto now = trellis::core::time::Now();
   ASSERT_TRUE(trellis::core::time::TimePointToSeconds(now) == 0.0);
 
   trellis::core::time::SetSimulatedTime(now + std::chrono::milliseconds(1500));
@@ -90,11 +92,38 @@ TEST(TrellisTimeAPI, SetSimTime) {
 }
 
 TEST(TrellisTimeAPI, IncrementSimTime) {
-  auto now = trellis::core::time::Now();
+  const auto now = trellis::core::time::Now();
 
   trellis::core::time::IncrementSimulatedTime(std::chrono::milliseconds(1500));
-  auto future = trellis::core::time::Now();
+  const auto future = trellis::core::time::Now();
 
   auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(future - now);
   ASSERT_EQ(delta.count(), 1500);
+}
+
+TEST(TrellisTimeAPI, SystemTimeConversion) {
+  const time::TimePoint start(std::chrono::milliseconds(500));
+  const time::TimePoint end(std::chrono::milliseconds(2500));
+
+  trellis::core::time::SetSimulatedTime(start);
+  const auto system_start = time::TimePointToSystemTime(start);
+  const auto system_end = time::TimePointToSystemTime(end);
+
+  const auto dt = system_end - system_start;
+  const auto dt_ms = std::chrono::duration_cast<std::chrono::milliseconds>(system_end - system_start).count();
+
+  ASSERT_TRUE(system_end > system_start);
+  ASSERT_EQ(dt_ms, 2000);
+
+  const auto system_seconds_start_absolute =
+      std::chrono::duration_cast<std::chrono::seconds>(system_start.time_since_epoch()).count();
+  const auto system_seconds_end_absolute =
+      std::chrono::duration_cast<std::chrono::seconds>(system_end.time_since_epoch()).count();
+
+  // Sanity check on the absolute system time by expecting it to be more recent than
+  // when this test was written (in seconds since epoch). The caveat us that the system time of the
+  // machine running this test needs to be sane. Remove this check if it becomes a problem.
+  ASSERT_TRUE(system_seconds_start_absolute > 1651626686);
+  // And for good measure make sure they're two seconds off in absolute time too
+  ASSERT_EQ(system_seconds_start_absolute + 2, system_seconds_end_absolute);
 }

--- a/trellis/core/time.cpp
+++ b/trellis/core/time.cpp
@@ -78,6 +78,13 @@ void SetSimulatedTime(const trellis::core::time::TimePoint& now) {
 
 void IncrementSimulatedTime(const std::chrono::milliseconds& duration) { SetSimulatedTime(simulated_now_ + duration); }
 
+SystemTimePoint TimePointToSystemTime(const TimePoint& time) {
+  // Subtract a duration in trellis clock domain (steady clock) from current system clock
+  // to get the equivalent time in system clock domain
+  return std::chrono::system_clock::now() +
+         std::chrono::duration_cast<std::chrono::system_clock::duration>(time - Now());
+}
+
 }  // namespace time
 }  // namespace core
 }  // namespace trellis

--- a/trellis/core/time.hpp
+++ b/trellis/core/time.hpp
@@ -25,6 +25,7 @@ namespace core {
 namespace time {
 
 using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+using SystemTimePoint = std::chrono::time_point<std::chrono::system_clock>;
 
 /**
  * now Get the current time
@@ -118,6 +119,11 @@ TimePoint TimePointFromFromTimestampedMessage(const trellis::core::TimestampedMe
  * TimePointToTimestamp create a google::protobuf::Timestamp from a time point
  */
 google::protobuf::Timestamp TimePointToTimestamp(const trellis::core::time::TimePoint& tp);
+
+/**
+ * TimePointToSystemTime get the system time associated with a given time point
+ */
+SystemTimePoint TimePointToSystemTime(const TimePoint& time);
 
 }  // namespace time
 }  // namespace core


### PR DESCRIPTION
Adds an API to convert `time::TimePoint` values into system time, which is useful for reporting / logging.