### PR TITLE
Isolate logging to separate cc_library with cpp file

### DIFF
--- a/trellis/core/BUILD
+++ b/trellis/core/BUILD
@@ -47,15 +47,28 @@ cc_library(
 )
 
 cc_library(
-    name = "core_ecal",
+    name = "core_logging",
     srcs = [
         "logging.cpp",
+    ],
+    hdrs = [
+        "logging.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ecal",
+        "@fmt",
+    ],
+)
+
+cc_library(
+    name = "core_ecal",
+    srcs = [
         "monitor_interface.cpp",
         "node.cpp",
         "transforms.cpp",
     ],
     hdrs = [
-        "logging.hpp",
         "message_consumer.hpp",
         "monitor_interface.hpp",
         "node.hpp",
@@ -68,9 +81,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":core",
+        ":core_logging",
         "//trellis/containers",
         "@ecal",
-        "@fmt",
     ],
 )
 

--- a/trellis/core/BUILD
+++ b/trellis/core/BUILD
@@ -49,6 +49,7 @@ cc_library(
 cc_library(
     name = "core_ecal",
     srcs = [
+        "logging.cpp",
         "monitor_interface.cpp",
         "node.cpp",
         "transforms.cpp",

--- a/trellis/core/logging.cpp
+++ b/trellis/core/logging.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Agtonomy
+ * Copyright (C) 2022 Agtonomy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,11 @@ namespace Log {
 namespace {
 
 eCAL_Logging_eLogLevel LogLevelToEcalLevel(LogLevel level) {
-  return std::unordered_map<LogLevel, eCAL_Logging_eLogLevel>{
-      {kInfo, log_level_info},   {kWarn, log_level_warning}, {kError, log_level_error},
-      {kFatal, log_level_fatal}, {kDebug, log_level_debug1},
-  }[level];
+  static const std::unordered_map<LogLevel, eCAL_Logging_eLogLevel> logmap {
+    {kInfo, log_level_info}, {kWarn, log_level_warning}, {kError, log_level_error}, {kFatal, log_level_fatal},
+        {kDebug, log_level_debug1},
+  }
+  return logmap[level];
 }
 
 }  // namespace

--- a/trellis/core/logging.cpp
+++ b/trellis/core/logging.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 Agtonomy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "logging.hpp"
+
+#include <ecal/ecal.h>
+
+namespace trellis {
+namespace core {
+namespace Log {
+
+namespace {
+
+eCAL_Logging_eLogLevel LogLevelToEcalLevel(LogLevel level) {
+  return std::unordered_map<LogLevel, eCAL_Logging_eLogLevel>{
+      {kInfo, log_level_info},   {kWarn, log_level_warning}, {kError, log_level_error},
+      {kFatal, log_level_fatal}, {kDebug, log_level_debug1},
+  }[level];
+}
+
+}  // namespace
+
+void DoLog(const std::string& msg, const std::string& prefix, LogLevel level) {
+  if (!eCAL::IsInitialized(eCAL::Init::Logging)) {
+    eCAL::Initialize(0, nullptr, nullptr, eCAL::Init::Logging);
+  }
+  const std::string full_msg = prefix + msg;
+  eCAL::Logging::Log(LogLevelToEcalLevel(level), full_msg);
+}
+
+}  // namespace Log
+}  // namespace core
+}  // namespace trellis

--- a/trellis/core/logging.cpp
+++ b/trellis/core/logging.cpp
@@ -26,11 +26,11 @@ namespace Log {
 namespace {
 
 eCAL_Logging_eLogLevel LogLevelToEcalLevel(LogLevel level) {
-  static const std::unordered_map<LogLevel, eCAL_Logging_eLogLevel> logmap {
-    {kInfo, log_level_info}, {kWarn, log_level_warning}, {kError, log_level_error}, {kFatal, log_level_fatal},
-        {kDebug, log_level_debug1},
-  }
-  return logmap[level];
+  static const std::unordered_map<LogLevel, eCAL_Logging_eLogLevel> logmap{
+      {kInfo, log_level_info},   {kWarn, log_level_warning}, {kError, log_level_error},
+      {kFatal, log_level_fatal}, {kDebug, log_level_debug1},
+  };
+  return logmap.at(level);
 }
 
 }  // namespace

--- a/trellis/core/logging.hpp
+++ b/trellis/core/logging.hpp
@@ -18,48 +18,42 @@
 #ifndef TRELLIS_CORE_LOGGING_HPP
 #define TRELLIS_CORE_LOGGING_HPP
 
-#include <ecal/ecal.h>
 #include <fmt/core.h>
 #include <unistd.h>
+
+#include <string>
 
 namespace trellis {
 namespace core {
 namespace Log {
 
-namespace {
+enum LogLevel { kInfo = 0, kWarn, kError, kFatal, kDebug };
 
-void DoLog(const std::string& msg, const std::string& prefix, eCAL_Logging_eLogLevel level) {
-  if (!eCAL::IsInitialized(eCAL::Init::Logging)) {
-    eCAL::Initialize(0, nullptr, nullptr, eCAL::Init::Logging);
-  }
-  const std::string full_msg = prefix + msg;
-  eCAL::Logging::Log(level, full_msg);
-}
+void DoLog(const std::string& msg, const std::string& prefix, LogLevel level);
 
-}  // namespace
 
 template <typename... Args>
 inline void Info(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  DoLog(msg, "[INFO]  ", log_level_info);
+  DoLog(msg, "[INFO]  ", LogLevel::kInfo);
 }
 
 template <typename... Args>
 inline void Warn(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  DoLog(msg, "[WARN]  ", log_level_warning);
+  DoLog(msg, "[WARN]  ", LogLevel::kWarn);
 }
 
 template <typename... Args>
 inline void Error(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  DoLog(msg, "[ERROR] ", log_level_error);
+  DoLog(msg, "[ERROR] ", LogLevel::kError);
 }
 
 template <typename... Args>
 inline void Fatal(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  DoLog(msg, "[FATAL] ", log_level_fatal);
+  DoLog(msg, "[FATAL] ", LogLevel::kFatal);
   // Sleep briefly because DoLog is not necessarily synchronous, so without sleeping this could abort before the fatal
   // log can be fully dispatched.
   sleep(1);
@@ -69,7 +63,7 @@ inline void Fatal(const std::string& fmt_msg, Args&&... args) {
 template <typename... Args>
 inline void Debug(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);
-  DoLog(msg, "[DEBUG] ", log_level_debug1);
+  DoLog(msg, "[DEBUG] ", LogLevel::kDebug);
 }
 
 }  // namespace Log

--- a/trellis/core/logging.hpp
+++ b/trellis/core/logging.hpp
@@ -31,7 +31,6 @@ enum LogLevel { kInfo = 0, kWarn, kError, kFatal, kDebug };
 
 void DoLog(const std::string& msg, const std::string& prefix, LogLevel level);
 
-
 template <typename... Args>
 inline void Info(const std::string& fmt_msg, Args&&... args) {
   std::string msg = fmt::format(fmt_msg, std::forward<Args>(args)...);


### PR DESCRIPTION
This makes it easier for other libraries to depend on logging only. Also, the eCAL dependency is limited to the cpp file now.