### PR TITLE
One Shot Timer Expired() logic fix

### DIFF
--- a/trellis/core/test/test_timer.cpp
+++ b/trellis/core/test/test_timer.cpp
@@ -52,19 +52,26 @@ TEST_F(TrellisFixture, OneShotTimerReset) {
   static unsigned fire_count{0};
   StartRunnerThread();
 
-  auto timer = node_.CreateOneShotTimer(30, []() { ++fire_count; });
+  auto timer = node_.CreateOneShotTimer(200, []() { ++fire_count; });
   ASSERT_EQ(timer->Expired(), false);
+
+  // Now it should still fire once after we wait
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  ASSERT_EQ(fire_count, 1U);
+  ASSERT_EQ(timer->Expired(), true);
+
   // Keep rapidly resetting the timer and let more time pass than the timer was
   // originally set for
-  for (unsigned i = 0; i < 100; ++i) {
+  for (unsigned i = 0; i < 1000; ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     timer->Reset();
   }
 
-  // Now it should still fire once after we wait
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-  ASSERT_EQ(fire_count, 1U);
+  ASSERT_EQ(timer->Expired(), false);
+  // Now it should still fire once more after we wait
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  ASSERT_EQ(fire_count, 2U);
+  ASSERT_EQ(timer->Expired(), true);
 }
 
 TEST_F(TrellisFixture, PeriodicTimerFiresMultipleTimes) {

--- a/trellis/core/timer.cpp
+++ b/trellis/core/timer.cpp
@@ -38,11 +38,12 @@ void TimerImpl::Reset() {
 
 void TimerImpl::Stop() {
   if (!SimulationActive()) {
+    cancelled_ = true;
     timer_->cancel();
   }
 }
 
-bool TimerImpl::Expired() const { return (type_ == kOneShot) ? did_fire_.load() : false; }
+bool TimerImpl::Expired() const { return (type_ == kOneShot) ? (did_fire_.load() || cancelled_.load()) : false; }
 
 void TimerImpl::KickOff() {
   if (!SimulationActive()) {
@@ -69,6 +70,7 @@ void TimerImpl::Reload() {
     last_fire_time_ = time::Now();  // this essentially pushes out the expiry time
   }
   did_fire_ = false;
+  cancelled_ = false;
 }
 
 void TimerImpl::Fire() {

--- a/trellis/core/timer.cpp
+++ b/trellis/core/timer.cpp
@@ -43,7 +43,7 @@ void TimerImpl::Stop() {
   }
 }
 
-bool TimerImpl::Expired() const { return (type_ == kOneShot) ? (did_fire_.load() || cancelled_.load()) : false; }
+bool TimerImpl::Expired() const { return did_fire_.load() || cancelled_.load(); }
 
 void TimerImpl::KickOff() {
   if (!SimulationActive()) {

--- a/trellis/core/timer.cpp
+++ b/trellis/core/timer.cpp
@@ -42,13 +42,11 @@ void TimerImpl::Stop() {
   }
 }
 
-bool TimerImpl::Expired() const { return expired_; }
+bool TimerImpl::Expired() const { return (type_ == kOneShot) ? did_fire_.load() : false; }
 
 void TimerImpl::KickOff() {
   if (!SimulationActive()) {
-    expired_ = false;
     timer_->async_wait([this](const trellis::core::error_code& e) {
-      expired_ = true;
       if (e) {
         return;
       }

--- a/trellis/core/timer.hpp
+++ b/trellis/core/timer.hpp
@@ -96,6 +96,7 @@ class TimerImpl {
   std::unique_ptr<asio::steady_timer> timer_;
   time::TimePoint last_fire_time_{time::Now()};
   std::atomic<bool> did_fire_{false};
+  std::atomic<bool> cancelled_{false};
 };
 
 using Timer = std::shared_ptr<TimerImpl>;

--- a/trellis/core/timer.hpp
+++ b/trellis/core/timer.hpp
@@ -94,9 +94,8 @@ class TimerImpl {
   const unsigned interval_ms_;
   const unsigned delay_ms_;
   std::unique_ptr<asio::steady_timer> timer_;
-  std::atomic<bool> expired_{true};
   time::TimePoint last_fire_time_{time::Now()};
-  bool did_fire_{false};
+  std::atomic<bool> did_fire_{false};
 };
 
 using Timer = std::shared_ptr<TimerImpl>;


### PR DESCRIPTION
There were cases where `Expired()` may return the wrong value for one shot timers. This PR fixes the logic to be more robust.