### PR TITLE
Cleanup 'raw' topic mechanism

### DIFF
--- a/trellis/core/monitor_interface.cpp
+++ b/trellis/core/monitor_interface.cpp
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <sstream>
 
+#include "proto_utils.hpp"
+
 namespace trellis {
 namespace core {
 
@@ -153,18 +155,7 @@ std::string MonitorInterface::FindFirstTopicNameForProtoType(const std::string& 
 
 void MonitorInterface::PrintTopics() const {
   const auto& topics = snapshot_.topics();
-  auto filter = [](const eCAL::pb::Topic& topic) {
-    const auto& name = topic.tname();
-    if (name.size() >= 4) {
-      const std::string suffix = name.substr(name.size() - 4, name.size());
-      // XXX (bsirang) the /raw entries are internal to trellis. These internal-only
-      // TODO improve the namespacing of these internal topic names
-      if (suffix == "/raw") {
-        return false;
-      }
-    }
-    return true;
-  };
+  auto filter = [](const eCAL::pb::Topic& topic) { return !proto_utils::IsRawTopic(topic.tname()); };
   PrintEntries<eCAL::pb::Topic>(topics, filter);
 }
 

--- a/trellis/core/proto_utils.hpp
+++ b/trellis/core/proto_utils.hpp
@@ -18,11 +18,15 @@
 #ifndef TRELLIS_CORE_PROTO_UTILS_HPP
 #define TRELLIS_CORE_PROTO_UTILS_HPP
 
-#include <ecal/protobuf/ecal_proto_dyn.h>
-
 namespace trellis {
 namespace core {
 namespace proto_utils {
+
+namespace {
+
+const std::string raw_topic_prefix = "/trellis/raw:";
+
+}
 
 /**
  * GetTypeFromURL extracts the protobuf type string from a type URL
@@ -34,7 +38,32 @@ inline std::string GetTypeFromURL(const std::string& type_url) {
   return "proto:" + type_url.substr(type_url.find_first_of('/') + 1, type_url.size());
 }
 
-inline std::string GetRawTopicString(const std::string& topic) { return topic + "/raw"; }
+/**
+ * GetRawTopicString get the raw topic name for a given topic
+ *
+ * Each Trellis topic publishes a "TimestampedMessage" and has an associated "raw" topic that advertises the actual
+ * message type. This function returns the associated raw topic name.
+ */
+inline std::string GetRawTopicString(const std::string& topic) { return raw_topic_prefix + topic; }
+
+/**
+ * IsRawTopic return true if the given topic name is a "raw" topic as described above
+ */
+inline bool IsRawTopic(const std::string& topic) {
+  return topic.size() > raw_topic_prefix.size() && topic.substr(0, raw_topic_prefix.size()) == raw_topic_prefix;
+}
+
+/**
+ * GetTopicFromRawTopic get the topic name given a raw topic
+ *
+ * This is the inverse of GetRawTopicString
+ */
+inline std::string GetTopicFromRawTopic(const std::string& raw_topic) {
+  if (!IsRawTopic(raw_topic)) {
+    return raw_topic;
+  }
+  return raw_topic.substr(raw_topic_prefix.size(), raw_topic.size() - raw_topic_prefix.size());
+}
 
 }  // namespace proto_utils
 }  // namespace core

--- a/trellis/core/proto_utils.hpp
+++ b/trellis/core/proto_utils.hpp
@@ -39,18 +39,23 @@ inline std::string GetTypeFromURL(const std::string& type_url) {
 }
 
 /**
+ * IsRawTopic return true if the given topic name is a "raw" topic as described above
+ */
+inline bool IsRawTopic(const std::string& topic) {
+  return topic.size() > raw_topic_prefix.size() && topic.substr(0, raw_topic_prefix.size()) == raw_topic_prefix;
+}
+
+/**
  * GetRawTopicString get the raw topic name for a given topic
  *
  * Each Trellis topic publishes a "TimestampedMessage" and has an associated "raw" topic that advertises the actual
  * message type. This function returns the associated raw topic name.
  */
-inline std::string GetRawTopicString(const std::string& topic) { return raw_topic_prefix + topic; }
-
-/**
- * IsRawTopic return true if the given topic name is a "raw" topic as described above
- */
-inline bool IsRawTopic(const std::string& topic) {
-  return topic.size() > raw_topic_prefix.size() && topic.substr(0, raw_topic_prefix.size()) == raw_topic_prefix;
+inline std::string GetRawTopicString(const std::string& topic) {
+  if (IsRawTopic(topic)) {
+    return topic;
+  }
+  return raw_topic_prefix + topic;
 }
 
 /**

--- a/trellis/core/test/BUILD
+++ b/trellis/core/test/BUILD
@@ -120,3 +120,15 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "test_core_proto_utils",
+    srcs = [
+        "test_proto_utils.cpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//trellis/core",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/trellis/core/test/test_proto_utils.cpp
+++ b/trellis/core/test/test_proto_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Agtonomy
+ * Copyright (C) 2022 Agtonomy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trellis/core/test/test_proto_utils.cpp
+++ b/trellis/core/test/test_proto_utils.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 Agtonomy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "trellis/core/proto_utils.hpp"
+
+using namespace trellis::core;
+
+TEST(TrellisProtoUtils, RawTopicNameTest) {
+  const std::string topic_name = "foo_bar";
+  const std::string raw_topic_name = proto_utils::GetRawTopicString(topic_name);
+  ASSERT_TRUE(proto_utils::IsRawTopic(raw_topic_name));
+  ASSERT_FALSE(proto_utils::IsRawTopic(topic_name));
+  ASSERT_TRUE(proto_utils::IsRawTopic("/trellis/raw:hello_world"));
+  ASSERT_EQ(proto_utils::GetTopicFromRawTopic("/trellis/raw:hello_world"), "hello_world");
+}

--- a/trellis/tools/trellis-cli/topic/topic_list_main.cpp
+++ b/trellis/tools/trellis-cli/topic/topic_list_main.cpp
@@ -20,6 +20,7 @@
 
 #include "VariadicTable.h"
 #include "trellis/core/monitor_interface.hpp"
+#include "trellis/core/proto_utils.hpp"
 #include "trellis/tools/trellis-cli/constants.hpp"
 
 namespace trellis {
@@ -47,15 +48,6 @@ std::string StringifySet(const std::unordered_set<std::string>& set) {
   return result;
 }
 
-bool IsRawTopic(const std::string& topic) {
-  // check if name ends with "/raw"
-  if (topic.size() >= 4) {
-    return topic.substr(topic.size() - 4, topic.size()) == "/raw";
-  }
-
-  return false;
-}
-
 int topic_list_main(int argc, char* argv[]) {
   cxxopts::Options options(topic_list_command.data(), topic_list_command_desc.data());
   options.add_options()("h,help", "print usage")("r,raw", "raw dump");
@@ -81,10 +73,10 @@ int topic_list_main(int argc, char* argv[]) {
 
     for (const auto& topic : snapshot.topics()) {
       const bool is_publisher = (topic.direction() == "publisher");
-      if (IsRawTopic(topic.tname())) {
+      if (trellis::core::proto_utils::IsRawTopic(topic.tname())) {
         if (is_publisher) {
           // We grab the real type from the raw topic
-          const std::string actual_topic_name = topic.tname().substr(0, topic.tname().size() - 4);
+          const std::string actual_topic_name = core::proto_utils::GetTopicFromRawTopic(topic.tname());
           topic_map[actual_topic_name].types.insert(topic.ttype());
         }
       } else {


### PR DESCRIPTION
We have a notion of a "raw" topic associated with every topic as a way of advertising additional metadata to the monitoring layer.

Previously we would append "/raw" to every topic name. Now instead we prepend "/trellis/raw:" to better namespace the topic strings that are internal to trellis.