### PR TITLE
Publisher Zero Copy Support

### DIFF
--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -88,6 +88,21 @@ class Node {
   }
 
   /**
+   * CreateZeroCopyPublisher create a new handle for a zero-copy publisher
+   *
+   * @tparam MSG_T the message type that will be published by this handle
+   * @param topic the topic name to publish to
+   *
+   * @return a handle to a publisher instance
+   *
+   * Note: A zero-copy publisher should only be used for larger payloads (i.e. in the megabytes)
+   */
+  template <typename MSG_T>
+  Publisher<MSG_T> CreateZeroCopyPublisher(std::string topic) const {
+    return std::make_shared<PublisherClass<MSG_T>>(topic.c_str(), true);
+  }
+
+  /**
    * CreateSubscriber create a new handle for a subscriber
    *
    * @tparam MSG_T the message type that we expect to receive from the publisher

--- a/trellis/core/node.hpp
+++ b/trellis/core/node.hpp
@@ -83,7 +83,7 @@ class Node {
    * @return a handle to a publisher instance
    */
   template <typename MSG_T>
-  Publisher<MSG_T> CreatePublisher(std::string topic) const {
+  Publisher<MSG_T> CreatePublisher(const std::string& topic) const {
     return std::make_shared<PublisherClass<MSG_T>>(topic.c_str());
   }
 
@@ -98,7 +98,7 @@ class Node {
    * Note: A zero-copy publisher should only be used for larger payloads (i.e. in the megabytes)
    */
   template <typename MSG_T>
-  Publisher<MSG_T> CreateZeroCopyPublisher(std::string topic) const {
+  Publisher<MSG_T> CreateZeroCopyPublisher(const std::string& topic) const {
     return std::make_shared<PublisherClass<MSG_T>>(topic.c_str(), true);
   }
 
@@ -118,7 +118,7 @@ class Node {
    * @return a subscriber handle
    */
   template <typename MSG_T>
-  Subscriber<MSG_T> CreateSubscriber(std::string topic,
+  Subscriber<MSG_T> CreateSubscriber(const std::string& topic,
                                      typename trellis::core::SubscriberImpl<MSG_T>::Callback callback,
                                      std::optional<unsigned> watchdog_timeout_ms = {},
                                      typename SubscriberImpl<MSG_T>::WatchdogCallback watchdog_callback = {},
@@ -153,7 +153,7 @@ class Node {
    *
    * @return a publisher handle
    */
-  DynamicPublisher CreateDynamicPublisher(std::string topic) const {
+  DynamicPublisher CreateDynamicPublisher(const std::string& topic) const {
     return std::make_shared<PublisherClass<google::protobuf::Message>>(topic);
   }
 
@@ -172,7 +172,7 @@ class Node {
    * @return a subscriber handle
    */
   DynamicSubscriber CreateDynamicSubscriber(
-      std::string topic, typename trellis::core::SubscriberImpl<google::protobuf::Message>::Callback callback,
+      const std::string& topic, typename trellis::core::SubscriberImpl<google::protobuf::Message>::Callback callback,
       std::optional<unsigned> watchdog_timeout_ms = {},
       typename SubscriberImpl<google::protobuf::Message>::WatchdogCallback watchdog_callback = {},
       std::optional<double> max_frequency = {}) {

--- a/trellis/core/publisher.hpp
+++ b/trellis/core/publisher.hpp
@@ -30,7 +30,15 @@ namespace core {
 template <typename MSG_T>
 class PublisherClass {
  public:
-  PublisherClass(const std::string& topic) : ecal_pub_(topic), ecal_pub_raw_(CreateRawPublisher(topic)) {}
+  PublisherClass(const std::string& topic) : PublisherClass(topic, false) {}
+
+  PublisherClass(const std::string& topic, bool enable_zero_copy)
+      : ecal_pub_(topic), ecal_pub_raw_(CreateRawPublisher(topic)) {
+    if (enable_zero_copy) {
+      ecal_pub_.ShmEnableZeroCopy(true);
+      ecal_pub_.ShmSetBufferCount(3);
+    }
+  }
   void Send(const MSG_T& msg) {
     const auto now = trellis::core::time::Now();
     Send(msg, now);

--- a/trellis/core/publisher.hpp
+++ b/trellis/core/publisher.hpp
@@ -36,6 +36,9 @@ class PublisherClass {
       : ecal_pub_(topic), ecal_pub_raw_(CreateRawPublisher(topic)) {
     if (enable_zero_copy) {
       ecal_pub_.ShmEnableZeroCopy(true);
+
+      // Use multi buffering to ensure the publisher is not contending for buffer space with subscribers. Double
+      // buffering is likely okay, but we'll use triple buffering for good measure.
       ecal_pub_.ShmSetBufferCount(3);
     }
   }


### PR DESCRIPTION
eCAL has a zero-copy feature for publishers, which is meant for larger messages. This PR brings in support for that feature for Trellis publishers.

Here's more info: https://continental.github.io/ecal/_api/classeCAL_1_1CPublisher.html#_CPPv4N4eCAL10CPublisher17ShmEnableZeroCopyEb