### PR TITLE
Cleanup cc_library dependencies

### DIFF
--- a/trellis/BUILD
+++ b/trellis/BUILD
@@ -4,17 +4,6 @@ cc_library(
     deps = [
         "//trellis/containers",
         "//trellis/core",
-        #"//trellis/core:core_ecal",
         "//trellis/network",
-    ],
-)
-
-# Produce a shared object that can be exported and used in other projects with non-Bazel build systems
-cc_binary(
-    name = "trellis.so",
-    linkshared = True,
-    visibility = ["//visibility:public"],
-    deps = [
-        ":trellis",
     ],
 )

--- a/trellis/BUILD
+++ b/trellis/BUILD
@@ -4,7 +4,7 @@ cc_library(
     deps = [
         "//trellis/containers",
         "//trellis/core",
-        "//trellis/core:core_ecal",
+        #"//trellis/core:core_ecal",
         "//trellis/network",
     ],
 )

--- a/trellis/core/BUILD
+++ b/trellis/core/BUILD
@@ -1,18 +1,79 @@
 cc_library(
     name = "core",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":core_bind",
+        ":core_config",
+        ":core_error_code",
+        ":core_event_loop",
+        ":core_logging",
+        ":core_message_consumer",
+        ":core_monitor_interface",
+        ":core_node",
+        ":core_proto",
+        ":core_proto_utils",
+        ":core_publisher",
+        ":core_service_client",
+        ":core_service_server",
+        ":core_subscriber",
+        ":core_time",
+        ":core_transforms",
+    ],
+)
+
+cc_library(
+    name = "core_bind",
+    hdrs = [
+        "bind.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)
+
+cc_library(
+    name = "core_error_code",
+    hdrs = [
+        "error_code.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@asio",
+    ],
+)
+
+cc_library(
+    name = "core_event_loop",
+    hdrs = [
+        "event_loop.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)
+
+cc_library(
+    name = "core_proto_utils",
+    hdrs = [
+        "proto_utils.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)
+
+cc_library(
+    name = "core_timer",
     srcs = [
         "timer.cpp",
     ],
     hdrs = [
-        "bind.hpp",
-        "error_code.hpp",
-        "event_loop.hpp",
-        "proto_utils.hpp",
         "timer.hpp",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":core_config",
+        ":core_error_code",
+        ":core_event_loop",
         ":core_time",
         "@asio",
     ],
@@ -63,27 +124,114 @@ cc_library(
 )
 
 cc_library(
-    name = "core_ecal",
+    name = "core_node",
+    srcs = [
+        "node.cpp",
+    ],
+    hdrs = [
+        "node.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":core_bind",
+        ":core_config",
+        ":core_event_loop",
+        ":core_proto_utils",
+        ":core_publisher",
+        ":core_service_client",
+        ":core_service_server",
+        ":core_subscriber",
+        "@ecal",
+    ],
+)
+
+cc_library(
+    name = "core_monitor_interface",
     srcs = [
         "monitor_interface.cpp",
-        "node.cpp",
+    ],
+    hdrs = [
+        "monitor_interface.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":core_proto_utils",
+        "@ecal",
+    ],
+)
+
+cc_library(
+    name = "core_transforms",
+    srcs = [
         "transforms.cpp",
     ],
     hdrs = [
-        "message_consumer.hpp",
-        "monitor_interface.hpp",
-        "node.hpp",
-        "publisher.hpp",
-        "service_client.hpp",
-        "service_server.hpp",
-        "subscriber.hpp",
         "transforms.hpp",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":core",
-        ":core_logging",
+        ":core_config",
+        ":core_message_consumer",
+        ":core_node",
         "//trellis/containers",
+    ],
+)
+
+cc_library(
+    name = "core_message_consumer",
+    hdrs = [
+        "message_consumer.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//trellis/containers",
+    ],
+)
+
+cc_library(
+    name = "core_publisher",
+    hdrs = [
+        "publisher.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":core_proto_utils",
+        ":core_time",
+        "@ecal",
+    ],
+)
+
+cc_library(
+    name = "core_service_client",
+    hdrs = [
+        "service_client.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":core_timer",
+        "@ecal",
+    ],
+)
+
+cc_library(
+    name = "core_service_server",
+    hdrs = [
+        "service_server.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ecal",
+    ],
+)
+
+cc_library(
+    name = "core_subscriber",
+    hdrs = [
+        "subscriber.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":core_monitor_interface",
         "@ecal",
     ],
 )

--- a/trellis/core/test/BUILD
+++ b/trellis/core/test/BUILD
@@ -16,7 +16,7 @@ cc_library(
         "test_fixture.hpp",
     ],
     deps = [
-        "//trellis/core:core_ecal",
+        "//trellis/core:core_node",
         "@gtest//:gtest_main",
     ],
 )
@@ -30,6 +30,7 @@ cc_test(
     deps = [
         ":test_fixture",
         ":test_proto",
+        "//trellis/core:core_message_consumer",
     ],
 )
 
@@ -86,7 +87,7 @@ cc_test(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//trellis/core:core_ecal",
+        "//trellis/core:core_time",
         "@gtest//:gtest_main",
     ],
 )
@@ -100,7 +101,7 @@ cc_test(
     deps = [
         ":test_fixture",
         ":test_proto",
-        "//trellis/core:core_ecal",
+        "//trellis/core:core_time",
         "@gtest//:gtest_main",
     ],
 )
@@ -128,7 +129,7 @@ cc_test(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//trellis/core",
+        "//trellis/core:core_proto_utils",
         "@gtest//:gtest_main",
     ],
 )

--- a/trellis/network/BUILD
+++ b/trellis/network/BUILD
@@ -6,7 +6,8 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//trellis/core",
+        "//trellis/core:core_error_code",
+        "//trellis/core:core_event_loop",
     ],
 )
 


### PR DESCRIPTION
Following better practices and making cc_library rules much more granular. It has the benefit of avoiding circular dependencies. It also has the benefit of making Bazel more aware of the source code dependencies, and minimizes what gets rebuilt when source files are edited.