### PR TITLE
Timer: Don't keep firing if canceled

### DIFF
--- a/trellis/core/test/timer_test.cpp
+++ b/trellis/core/test/timer_test.cpp
@@ -15,11 +15,14 @@
  *
  */
 
+#include "trellis/core/timer.hpp"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <iostream>
 
+#include "trellis/core/event_loop.hpp"
 #include "trellis/core/test/test_fixture.hpp"
 
 using trellis::core::test::TrellisFixture;
@@ -96,4 +99,20 @@ TEST_F(TrellisFixture, PeriodicTimerStopsProperly) {
 
   // Periodic timer fires immediately, so we expect it fired once before we stopped it
   ASSERT_EQ(fire_count, 1U);
+}
+
+TEST_F(TrellisFixture, PeriodicTimerStopsWithinCallback) {
+  static unsigned fire_count{0};
+  StartRunnerThread();
+
+  std::shared_ptr<trellis::core::TimerImpl> timer =
+      node_.CreateTimer(10, [&timer](const trellis::core::time::TimePoint&) {
+        if (++fire_count == 5) {
+          timer->Stop();
+        }
+      });
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Periodic timer fires immediately, so we expect it fired once before we stopped it
+  ASSERT_EQ(fire_count, 5);
 }

--- a/trellis/core/test/timer_test.cpp
+++ b/trellis/core/test/timer_test.cpp
@@ -15,14 +15,11 @@
  *
  */
 
-#include "trellis/core/timer.hpp"
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <iostream>
 
-#include "trellis/core/event_loop.hpp"
 #include "trellis/core/test/test_fixture.hpp"
 
 using trellis::core::test::TrellisFixture;

--- a/trellis/core/timer.cpp
+++ b/trellis/core/timer.cpp
@@ -37,8 +37,8 @@ void TimerImpl::Reset() {
 }
 
 void TimerImpl::Stop() {
+  cancelled_ = true;
   if (!SimulationActive()) {
-    cancelled_ = true;
     timer_->cancel();
   }
 }
@@ -81,7 +81,7 @@ void TimerImpl::Fire() {
   last_fire_time_ = now;  // used for sim time
   did_fire_ = true;
   callback_(now);
-  if (type_ != kOneShot) {
+  if (type_ != kOneShot && !cancelled_) {
     Reload();
     KickOff();
   }


### PR DESCRIPTION
There were previously situations where the periodic callbacks would still fire after `Stop()` was requested.
This fix addresses that issue and adds a new unit test that catches that scenario.

New unit test fails without the timer.hpp change:
```
trellis/core/test/timer_test.cpp:139: Failure
Expected equality of these values:
  fire_count
    Which is: 10
  5
```