### PR TITLE
[bazel] Switch to grpc py_proto_library rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,11 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
+# Remove after we switch to rules_python's py_proto_library:
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -78,10 +78,22 @@ def trellis_deps():
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568",
-        strip_prefix = "protobuf-3.19.4",
+        sha256 = "1add10f9bd92775b91f326da259f243881e904dd509367d5031d4c782ba82810",
+        strip_prefix = "protobuf-3.21.9",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/v3.19.4.tar.gz",
+                "https://github.com/protocolbuffers/protobuf/archive/v3.21.9.tar.gz",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        # Remove once we switch from the grpc py_proto_library to the rules_python py_proto_library
+        name = "com_github_grpc_grpc",
+        sha256 = "8c05641b9f91cbc92f51cc4a5b3a226788d7a63f20af4ca7aaca50d92cc94a0d",
+        strip_prefix = "grpc-1.44.0",
+        urls = [
+            "https://github.com/grpc/grpc/archive/v1.44.0.tar.gz",
+            "http://dependency-mirror.s3.amazonaws.com/haystack/grpc-v1.44.0.tar.gz",
         ],
     )
 

--- a/trellis/core/BUILD.bazel
+++ b/trellis/core/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
+load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library")
 
 cc_library(
     name = "core",
@@ -298,14 +298,8 @@ cc_proto_library(
 
 py_proto_library(
     name = "python_core_proto_lib",
-    srcs = [
-        "health_history.proto",
-        "health_status.proto",
-        "quaternion.proto",
-        "rigid_transform.proto",
-        "timestamped_message.proto",
-        "vector3.proto",
-    ],
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:protobuf_python"],
+    deps = [
+        ":core_proto_lib",
+    ],
 )


### PR DESCRIPTION
The current py_proto_library rule we use from protobuf breaks after
protobuf v3.20.3 and there are no newer rules which are compatible with
the syntax, so we must move to grpc's py_proto_library implementation,
which is different in that the py_proto_library doesn't take .proto
files as srcs, instead it accepts exactly one proto_library label in
deps, the py_proto_library inherits dependencies and sources from the
proto_library. This requires upgrading protobuf (v3.21.9 is the furthest
possible due to other interdependencies in the haystack repo,) and
adding grpc as a dependency.

As of this commit the trellis repo should be compatible with bazel
versions up to 7.3.1.
