### PR TITLE
Remove redefinition of SubscriberImpl

### DIFF
--- a/trellis/core/subscriber.hpp
+++ b/trellis/core/subscriber.hpp
@@ -331,10 +331,6 @@ class SubscriberImpl : public std::enable_shared_from_this<SubscriberImpl<MSG_T>
   unsigned dropped_message_count_{0};                     ///< Total number of dropped messages detected
 };
 
-/// @brief Alias for consistency with other versions.
-template <typename MSG_T>
-using SubscriberImpl = SubscriberImpl<MSG_T>;
-
 /// @brief Alias for shared pointer to subscriber.
 template <typename MSG_T>
 using Subscriber = std::shared_ptr<SubscriberImpl<MSG_T>>;


### PR DESCRIPTION
`clangd` does not like the redefinition of this symbol. `SubscriberImpl` is first declared as a class. I don't see any reason why this is actually necessary.

```
[{
	"resource": "/workspace/.cache/bazel/_bazel_ag/947520f8c2d295d4c795226754f7f58e/external/com_github_agtonomy_trellis/trellis/core/subscriber.hpp",
	"owner": "_generated_diagnostic_collection_name_#0",
	"code": "redefinition_different_kind",
	"severity": 8,
	"message": "Redefinition of 'SubscriberImpl' as different kind of symbol",
	"source": "clang",
	"startLineNumber": 329,
	"startColumn": 1,
	"endLineNumber": 329,
	"endColumn": 6,
	"relatedInformation": [
		{
			"startLineNumber": 42,
			"startColumn": 7,
			"endLineNumber": 42,
			"endColumn": 21,
			"message": "Previous definition is here",
			"resource": "/workspace/.cache/bazel/_bazel_ag/947520f8c2d295d4c795226754f7f58e/external/com_github_agtonomy_trellis/trellis/core/subscriber.hpp"
		}
	],
	"origin": "extHost2"
}]
```